### PR TITLE
chore: 개발환경 설정 개선 및 polling 주기 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
   mysql:
     image: mysql:8
     ports:
-      - "3306:3306"
+      - "3307:3306"
     environment:
       MYSQL_ROOT_PASSWORD: 1234
     volumes:
@@ -153,6 +153,7 @@ services:
       KAFKA_HOST: kafka
       EXTERNAL_DEPOSITS_BASE_URL: http://user-service:9003
       EXTERNAL_PRODUCTS_BASE_URL: http://product-service:9004
+      EXTERNAL_PAYMENTS_BASE_URL: http://payment-service:9001
     depends_on:
       mysql:
         condition: service_healthy
@@ -236,6 +237,13 @@ services:
       MYSQL_USER: root
       MYSQL_PASSWORD: 1234
       SPRING_DATA_REDIS_HOST: redis
+      USER_SERVICE_URL: http://user-service:9003
+      PAYMENT_SERVICE_URL: http://payment-service:9001
+      PRODUCT_SERVICE_URL: http://product-service:9004
+      ORDER_SERVICE_URL: http://order-service:9005
+      SETTLEMENT_SERVICE_URL: http://settlement-service:9002
+      ADMIN_SERVICE_URL: http://admin-service:9007
+      AI_SERVICE_URL: http://ai-service:9009
     depends_on:
       mysql:
         condition: service_healthy
@@ -260,7 +268,7 @@ services:
   grafana:
     image: grafana/grafana:10.4.2
     ports:
-      - "3000:3000"
+      - "3001:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=1234

--- a/service/order/src/main/java/jabaclass/order/infrastructure/outbox/OutboxPublisher.java
+++ b/service/order/src/main/java/jabaclass/order/infrastructure/outbox/OutboxPublisher.java
@@ -21,7 +21,7 @@ public class OutboxPublisher {
 	private final OutboxService outboxService;
 	private final KafkaTemplate<String, String> kafkaTemplate;
 
-	@Scheduled(fixedDelay = 1000)
+	@Scheduled(fixedDelay = 3000)
 	public void publish() {
 		LocalDateTime threshold = LocalDateTime.now().minusMinutes(5);
 		List<OutboxEvent> events =
@@ -49,9 +49,10 @@ public class OutboxPublisher {
 
 				kafkaTemplate.send(record).get();
 				outboxService.markPublished(event);
+				log.info("[Outbox] 발행 완료. eventType={}, aggregateId={}", event.getEventType(), event.getAggregateId());
 
 			} catch (Exception e) {
-				log.error("Outbox 발행 실패. eventId={}, eventType={}, error={}",
+				log.error("[Outbox] 발행 실패. eventId={}, eventType={}, error={}",
 					event.getId(), event.getEventType(), e.getMessage());
 				outboxService.retry(event);
 			}

--- a/service/order/src/main/resources/application-dev.yml
+++ b/service/order/src/main/resources/application-dev.yml
@@ -8,7 +8,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
     properties:
       hibernate:
         format_sql: true

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/outbox/OutboxPublisher.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/outbox/OutboxPublisher.java
@@ -10,7 +10,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OutboxPublisher {
@@ -19,7 +21,7 @@ public class OutboxPublisher {
 	private final OutboxService outboxService;
 	private final KafkaTemplate<String, String> kafkaTemplate;
 
-	@Scheduled(fixedDelay = 1000) // 1초마다 Outbox 이벤트 발행 시도
+	@Scheduled(fixedDelay = 3000)
 	public void publish() {
 
 		// SENDING 상태에서 멈춘 이벤트 찾기

--- a/service/payment/src/main/resources/application-dev.yml
+++ b/service/payment/src/main/resources/application-dev.yml
@@ -8,4 +8,4 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false

--- a/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxEvent.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxEvent.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.Lob;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
@@ -26,8 +25,7 @@ public class OutboxEvent extends EntityBase {
 	@Column(nullable = false)
 	private EsEventType eventType;
 
-	@Lob
-	@Column(nullable = false)
+	@Column(nullable = false, columnDefinition = "TEXT")
 	private String payload;
 
 	@Enumerated(EnumType.STRING)

--- a/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxPublisher.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/outbox/OutboxPublisher.java
@@ -21,7 +21,7 @@ public class OutboxPublisher {
 	private final OutboxService outboxService;
 	private final KafkaTemplate<String, String> kafkaTemplate;
 
-	@Scheduled(fixedDelay = 1000)
+	@Scheduled(fixedDelay = 3000)
 	public void publish() {
 		LocalDateTime threshold = LocalDateTime.now().minusMinutes(5);
 		List<OutboxEvent> events = outboxService.findAndMarkSending(threshold, 100);

--- a/service/product/src/main/resources/application-dev.yml
+++ b/service/product/src/main/resources/application-dev.yml
@@ -21,7 +21,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-    show-sql: true
+    show-sql: false
 
   cloud:
     aws:
@@ -42,5 +42,5 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: DEBUG            # 실제 실행되는 SQL
-    org.hibernate.type.descriptor.sql: TRACE  # 바인딩 파라미터까지
+    org.hibernate.SQL: WARN
+    org.hibernate.type.descriptor.sql: WARN


### PR DESCRIPTION
## 변경 요약
- docker-compose MySQL 포트 3307, Grafana 포트 3001로 변경 (로컬 충돌 방지)
- order-service EXTERNAL_PAYMENTS_BASE_URL 환경변수 추가
- OutboxPublisher fixedDelay 1000 → 3000ms (order, payment, product)
- order OutboxPublisher Kafka 발행 성공 로그 추가
- product OutboxEvent payload @Lob → @Column(columnDefinition = "TEXT") 변경


## 주요 변경점
- 

## 테스트
- [x] 로컬 실행 확인
- [x] 테스트 통과
