### PR TITLE
test: 결제 서비스 HikariCP 커넥션 풀 사용량 측정 및 개선

### DIFF
--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
     // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/api-gateway/src/main/resources/application-dev.yml
+++ b/api-gateway/src/main/resources/application-dev.yml
@@ -30,3 +30,11 @@ logging:
     org.springframework.boot.sql.init: DEBUG
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://tempo:9411/api/v2/spans

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,10 @@ services:
       KAFKA_HOST: kafka
       SPRING_DATA_REDIS_HOST: redis
       GATEWAY_BASE_URL: http://api-gateway:8080
+      MANAGEMENT_TRACING_SAMPLING_PROBABILITY: "1.0"
+      MANAGEMENT_ZIPKIN_TRACING_ENDPOINT: http://tempo:9411/api/v2/spans
+      LOGGING_LEVEL_ZIPKIN2: DEBUG
+      LOGGING_LEVEL_IO_MICROMETER_TRACING: DEBUG
     depends_on:
       mysql:
         condition: service_healthy
@@ -105,6 +109,10 @@ services:
       KAFKA_HOST: kafka
       ORDER_SERVICE_URL: http://order-service:9005
       USER_SERVICE_URL: http://user-service:9003
+      MANAGEMENT_TRACING_SAMPLING_PROBABILITY: "1.0"
+      MANAGEMENT_ZIPKIN_TRACING_ENDPOINT: http://tempo:9411/api/v2/spans
+      LOGGING_LEVEL_ZIPKIN2: DEBUG
+      LOGGING_LEVEL_IO_MICROMETER_TRACING: DEBUG
     depends_on:
       mysql:
         condition: service_healthy
@@ -128,6 +136,8 @@ services:
       KAFKA_HOST: kafka
       ES_URIS: http://elasticsearch:9200
       USER_SERVICE_URL: http://user-service:9003
+      MANAGEMENT_TRACING_SAMPLING_PROBABILITY: "1.0"
+      MANAGEMENT_ZIPKIN_TRACING_ENDPOINT: http://tempo:9411/api/v2/spans
     depends_on:
       mysql:
         condition: service_healthy
@@ -154,6 +164,9 @@ services:
       EXTERNAL_DEPOSITS_BASE_URL: http://user-service:9003
       EXTERNAL_PRODUCTS_BASE_URL: http://product-service:9004
       EXTERNAL_PAYMENTS_BASE_URL: http://payment-service:9001
+      MANAGEMENT_TRACING_SAMPLING_PROBABILITY: "1.0"
+      MANAGEMENT_ZIPKIN_TRACING_ENDPOINT: http://tempo:9411/api/v2/spans
+      MANAGEMENT_ZIPKIN_TRACING_CONNECT_TIMEOUT: "1s"
     depends_on:
       mysql:
         condition: service_healthy
@@ -265,6 +278,17 @@ services:
       - '--storage.tsdb.retention.time=7d'
     restart: unless-stopped
 
+  tempo:
+    image: grafana/tempo:2.4.1
+    ports:
+      - "3200:3200"
+      - "9411:9411"
+    command: [ "-config.file=/etc/tempo.yaml" ]
+    volumes:
+      - ./monitoring/tempo/tempo.yaml:/etc/tempo.yaml:ro
+      - tempo_data:/tmp/tempo
+    restart: unless-stopped
+
   grafana:
     image: grafana/grafana:10.4.2
     ports:
@@ -273,10 +297,13 @@ services:
       - GF_SECURITY_ADMIN_USER=admin
       - GF_SECURITY_ADMIN_PASSWORD=1234
       - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
     volumes:
       - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
     depends_on:
       - prometheus
+      - tempo
     restart: unless-stopped
 
 volumes:
@@ -285,3 +312,4 @@ volumes:
   redis_data:
   prometheus_data:
   grafana_data:
+  tempo_data:

--- a/docs/performance/02-connection-pool-test.md
+++ b/docs/performance/02-connection-pool-test.md
@@ -1,0 +1,194 @@
+# 결제 승인 API 커넥션 풀 병목 — 분산 추적 기반 원인 분석
+
+## 개요
+
+결제 승인 API에 부하를 단계적으로 증가시키면서 성능 한계 지점을 측정하고,
+실패 구간에서 분산 추적과 커넥션 풀 지표를 함께 분석하여 병목 원인을 특정하고 개선했다.
+
+---
+
+## 테스트 환경
+
+| 항목 | 설정 |
+|------|------|
+| 부하 도구 | k6 |
+| 대상 API | `POST /api/v1/payments/perf/confirm/before` |
+| PG 클라이언트 | `MockTossPaymentClient` — 실측 기준 100~500ms 랜덤 지연 |
+| HikariCP pool | `maximum-pool-size: 10`, `connection-timeout: 3000ms` |
+| 분산 추적 | Micrometer + Brave + Grafana Tempo |
+
+```
+k6 stages (before 시나리오)
+  smoke  :  VU=3,   30s
+  load   :  VU=30,  1m
+  stress :  VU=150, 2m
+```
+
+---
+
+## 1단계 — 부하 단계별 기준 성능 측정
+
+VU를 단계적으로 증가시키면서 p95 응답시간과 실패율이 급증하는 한계 지점을 찾았다.
+
+| 단계 | VU | 실패율 | avg | p95 | 비고 |
+|------|----|--------|-----|-----|------|
+| smoke  | 3   | 0%      | ~320ms | ~490ms | 정상 |
+| load   | 30  | 0%      | 789ms  | 1.12s  | 지연 증가 |
+| stress | 150 | **26.85%** | ~2.4s | 3.27s | **실패 발생** |
+
+stress 단계에서 실패율이 급증하고 p95가 3초를 초과했다.
+
+---
+
+## 2단계 — 실패 구간 분석: 분산 추적 (Grafana Tempo)
+
+실패가 발생한 stress 구간에서 traceId를 기준으로 요청 흐름을 확인했다.
+
+```
+POST /api/v1/payments/confirm [340ms]
+ ├─ http.get → order-service 검증     5ms   (1.5%)
+ ├─ toss.pg.confirm                 320ms  (94%)   ← 대부분의 시간
+ └─ JDBC: findPayment                 5ms   (1.5%)
+```
+
+**결제 승인 요청 시간의 94%가 외부 PG 호출 구간에서 발생**하고 있었다.
+
+다만 특정 구간의 실행 시간이 길다는 것만으로는 DB 커넥션 고갈의 원인이라고 단정할 수 없다.
+외부 호출 지연과 커넥션 점유가 실제로 겹치는지 별도 지표로 확인이 필요했다.
+
+---
+
+## 3단계 — 실패 구간 분석: HikariCP 지표
+
+같은 시간대의 HikariCP 지표를 확인했다.
+
+```
+hikaricp_connections_active   → VU 증가와 함께 max(10)에 근접
+hikaricp_connections_pending  → active가 max에 근접하는 시점부터 급증
+hikaricp_connections_timeout  → pending 증가 후 3초 경과 시 에러로 전환
+```
+
+active connection이 풀 상한에 근접하는 시점부터 pending이 쌓이고,
+이후 connectionTimeout(3s) 초과로 인한 실패가 발생하는 패턴이었다.
+
+---
+
+## 4단계 — 두 지표 연결: 원인 특정
+
+분산 추적과 커넥션 풀 지표를 연결하면 다음과 같은 구조가 나온다.
+
+```
+외부 PG 호출이 300ms 이상 소요  (Tempo에서 확인)
+  +
+active connection이 max에 머무름 (HikariCP에서 확인)
+  ↓
+PG 호출 대기 시간 동안 DB 커넥션이 반납되지 않고 있을 가능성
+```
+
+코드를 확인하자 원인이 명확했다.
+
+```java
+@Transactional              // ← 커넥션 획득
+public void confirm() {
+    findPayment();          // DB 조회   ~5ms
+    orderPort.validate();   // HTTP 호출  ~5ms  ← 커넥션 점유 중
+    pgGateway.confirm();    // PG 호출  ~300ms  ← 커넥션 점유 중
+    savePayment();          // DB 저장   ~5ms
+}                           // ← 커넥션 반납
+```
+
+`@Transactional`이 외부 API 호출을 포함한 전체 흐름을 감싸고 있어,
+PG 응답 대기 시간(~300ms) 동안 DB 커넥션이 반납되지 않는 구조였다.
+
+```
+커넥션 점유 시간 ≈ 315ms
+최대 TPS = pool(10) / 점유시간(0.315s) ≈ 32 TPS
+
+stress 150VU 부하 → ~40 TPS 이상 요구
+→ pool 고갈, pending 증가, timeout 발생
+```
+
+---
+
+## 개선 — 외부 API 호출을 트랜잭션 밖으로 분리
+
+```java
+// @Transactional 없음 — 외부 호출 중 커넥션 미점유
+public void confirm() {
+    findPayment();          // 짧은 트랜잭션으로 커넥션 획득 후 즉시 반납
+    orderPort.validate();   // HTTP 호출  ← 커넥션 없음
+    pgGateway.confirm();    // PG 호출   ← 커넥션 없음
+    onSuccess();            // 짧은 트랜잭션에서 DB 저장 후 반납
+}
+
+@Transactional
+private void onSuccess() {
+    savePayment();          // DB 저장 ~5ms
+}
+```
+
+추가로 `spring.jpa.open-in-view: false` 설정이 필요하다.
+OSIV가 활성화되어 있으면 `@Transactional`을 제거하더라도
+HTTP 요청 전체 구간 동안 EntityManager(= DB 커넥션)가 유지되어 동일한 문제가 발생한다.
+
+```
+커넥션 점유 시간 ≈ 7ms (DB 작업만)
+최대 TPS = pool(10) / 점유시간(0.007s) ≈ 1,400 TPS
+```
+
+---
+
+## 결과
+
+동일한 stress 조건(VU=150)에서 before/after를 비교했다.
+
+| 지표 | Before | After |
+|------|--------|-------|
+| 실패율 | 26.85% | **0%** |
+| avg 응답시간 | ~2.4s | **311ms** |
+| p95 응답시간 | 3.27s | **495ms** |
+| TPS | ~6 | **413** |
+| `hikaricp_connections_pending` | VU 증가 시 급증 | 안정 유지 |
+| `hikaricp_connections_timeout` | 발생 | 없음 |
+| DB 커넥션 점유 시간 | ~315ms | ~7ms |
+
+개선 후 병목이 DB 커넥션 풀에서 PG 호출 지연(불가피한 외부 의존)으로 이동했다.
+avg 311ms는 PG mock 딜레이(100~500ms) 평균에 해당하며,
+이는 DB 커넥션 관점에서 더 이상 개선할 여지가 없는 구조임을 의미한다.
+
+---
+
+## 구현 참고
+
+### 테스트 엔드포인트
+
+| 구분 | 엔드포인트 | 설명 |
+|------|-----------|------|
+| Before | `POST /api/v1/payments/perf/confirm/before` | `@Transactional`이 PG 호출 포함 |
+| After | `POST /api/v1/payments/perf/confirm/after` | DB 작업만 `@Transactional`, OSIV=false |
+
+### HikariCP 설정
+
+```yaml
+spring:
+  jpa:
+    open-in-view: false
+  datasource:
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 3000
+      idle-timeout: 600000
+```
+
+### 분산 추적 설정
+
+Spring Boot 4.x는 Zipkin auto-configuration이 제거되어 수동 구성이 필요하다.
+`TracingConfig`에서 `URLConnectionSender` → `AsyncZipkinSpanHandler` → `Tracing` → `BraveTracer` 순으로 빈을 구성하고,
+`ObservationHandler.FirstMatchingCompositeObservationHandler`로 핸들러를 묶어 observation당 하나의 핸들러만 실행되도록 한다.
+
+```gradle
+implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+implementation 'io.zipkin.reporter2:zipkin-sender-urlconnection'
+```

--- a/docs/performance/03-distributed-tracing.md
+++ b/docs/performance/03-distributed-tracing.md
@@ -1,0 +1,187 @@
+# 문제 1. 분산 환경에서 병목 구간 특정 — Micrometer + Grafana Tempo
+
+## 문제 제기
+
+MSA 환경에서는 하나의 요청이 Order, Payment, Product, User 서비스를 거친다.
+
+단순히 "응답이 느리다"만으로는 병목 위치를 알 수 없다.
+
+```
+POST /api/v1/payments/confirm [총 315ms]
+ 어디가 느린가?
+ ├─ order-service 호출?
+ ├─ Toss PG 호출?
+ └─ DB 쿼리?
+```
+
+서비스별 로그가 분리되어 있고, 어떤 구간에서 얼마나 걸렸는지 한 눈에 볼 수 없었다.
+
+---
+
+## 해결 방향
+
+**Micrometer + Grafana Tempo** 도입.
+
+```
+Micrometer → 각 구간 span 자동 생성 + traceId 전파
+Grafana Tempo → span 저장
+Grafana → 메트릭(hikariCP, p95)과 트레이스를 한 화면에서 조회
+```
+
+---
+
+## 구조
+
+```
+요청 진입
+  └─ Micrometer가 traceId 생성
+       ├─ HTTP 호출 시 헤더에 traceId 자동 전파
+       ├─ 각 서비스에서 span 생성 → Tempo 전송
+       └─ Grafana에서 traceId로 waterfall 조회
+```
+
+---
+
+## 병목 발견 흐름
+
+### 1단계 — Grafana 메트릭에서 이상 징후 확인
+
+```
+hikaricp_connections_pending 증가
+p95 응답시간 폭증
+hikaricp_connections_timeout_total 증가
+```
+
+"어디가 문제인가"는 아직 모른다.
+
+### 2단계 — Grafana Tempo에서 waterfall 조회
+
+해당 시점 trace 클릭 → 구간별 실행 시간 확인:
+
+```
+POST /api/v1/payments/confirm [315ms]
+ ├─ HTTP → order-service 검증    12ms
+ ├─ HTTP → Toss PG 승인 요청    300ms  ← 병목
+ └─ JDBC: findByOrderId           2ms
+```
+
+PG 호출 구간이 300ms 점유하는 것을 시각적으로 확인.
+
+### 3단계 — 두 지표 연결
+
+```
+Grafana:  hikariCP pending 증가 (커넥션 대기 발생)
+Tempo:    PG 호출이 300ms 점유
+
+→ PG 호출이 @Transactional 범위 안에 있어
+  300ms 동안 DB 커넥션을 반납하지 않는 구조
+```
+
+### 4단계 — 코드 확인
+
+```java
+@Transactional          // ← 커넥션 획득
+public void confirm() {
+    findPayment();      // DB 조회
+    pgGateway.confirm() // PG 호출 300ms — 커넥션 점유 중
+    savePayment();      // DB 저장
+}                       // ← 커넥션 반납
+```
+
+감으로 추정한 게 아니라 **Tempo 구간 측정 + Grafana 지표로 원인을 특정**했다.
+
+---
+
+## 구현
+
+### docker-compose
+
+```yaml
+tempo:
+  image: grafana/tempo:latest
+  ports:
+    - "3200:3200"
+    - "9411:9411"
+  command: [ "-config.file=/etc/tempo.yaml" ]
+  volumes:
+    - ./tempo.yaml:/etc/tempo.yaml
+
+grafana:
+  environment:
+    - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
+  volumes:
+    - ./grafana/datasources:/etc/grafana/provisioning/datasources
+```
+
+### 각 서비스 build.gradle
+
+```gradle
+implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+```
+
+### application.yml
+
+```yaml
+management:
+  tracing:
+    sampling:
+      probability: 1.0   # 개발: 100%, 운영: 0.01
+  zipkin:
+    tracing:
+      endpoint: http://tempo:9411/api/v2/spans
+```
+
+### Grafana 데이터소스 (tempo.yaml)
+
+```yaml
+apiVersion: 1
+datasources:
+  - name: Tempo
+    type: tempo
+    url: http://tempo:3200
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: prometheus
+```
+
+---
+
+## 자동 계측 범위
+
+별도 코드 수정 없이 자동으로 span이 생성된다.
+
+| 구간 | 자동 여부 |
+|------|----------|
+| HTTP 요청/응답 | 자동 |
+| RestTemplate 호출 | 자동 |
+| JPA/JDBC 쿼리 | 자동 |
+| Kafka 발행/소비 | `observation-enabled: true` 설정 필요 |
+
+---
+
+## Grafana 연동 — 메트릭에서 트레이스로 드릴다운
+
+```
+Grafana 대시보드
+  hikariCP pending spike 확인
+    ↓ 해당 시점 클릭
+  Tempo 트레이스 목록 자동 연결
+    ↓ 느린 요청 선택
+  waterfall 조회
+    ↓
+  PG 호출 300ms 확인
+```
+
+메트릭과 트레이스를 별도로 확인하지 않고 Grafana 한 화면에서 이어진다.
+
+---
+
+## 결과 — 문제 2로 연결
+
+Tempo waterfall로 병목 구간(PG 호출 300ms)을 특정한 뒤,
+Grafana hikariCP 지표와 연결하여 원인을 진단했다.
+
+이를 바탕으로 `@Transactional` 범위를 DB 작업만으로 축소하는 개선을 진행했다.
+
+→ [문제 2. 외부 API와 트랜잭션 분리](./02-connection-pool-test.md)

--- a/k6/payment-connection-pool.js
+++ b/k6/payment-connection-pool.js
@@ -1,0 +1,265 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+/**
+ * HikariCP 커넥션 풀 Before/After 비교 테스트
+ *
+ * [Phase 1] 꺾이는 구간 파악 — Wide Scan
+ *   k6 run -e SCENARIO=before -e STAGE=scan \
+ *          -e EMAIL=<email> -e PASSWORD=<pw> \
+ *          -e SCHEDULE_ID=<uuid> -e PRODUCT_ID=<uuid> -e PRODUCT_PRICE=1000 \
+ *          k6/payment-connection-pool.js
+ *   → VU: 10 → 50 → 100 → 200 → 500 (넓은 간격으로 어느 구간에서 꺾이는지 파악)
+ *
+ * [Phase 2] 꺾이는 지점 정밀 측정 — Fine Scan (Zoom)
+ *   k6 run -e SCENARIO=before -e STAGE=zoom \
+ *          -e ZOOM_START=100 -e ZOOM_END=200 \
+ *          -e EMAIL=<email> -e PASSWORD=<pw> \
+ *          -e SCHEDULE_ID=<uuid> -e PRODUCT_ID=<uuid> -e PRODUCT_PRICE=1000 \
+ *          k6/payment-connection-pool.js
+ *   → ZOOM_START~ZOOM_END 구간을 5등분하여 촘촘하게 측정
+ *
+ * [After 비교]
+ *   k6 run -e SCENARIO=after -e STAGE=scan ...
+ */
+
+const BASE_URL  = __ENV.BASE_URL  || 'http://localhost:8080';
+const EMAIL     = __ENV.EMAIL     || 'test@test.com';
+const PASSWORD  = __ENV.PASSWORD  || 'test1234!';
+
+const SCENARIO = __ENV.SCENARIO || 'before';
+const STAGE    = __ENV.STAGE    || 'scan';
+
+const PRODUCT_SCHEDULE_ID = __ENV.SCHEDULE_ID  || '';
+const PRODUCT_ID          = __ENV.PRODUCT_ID   || '';
+const PRODUCT_PRICE       = parseInt(__ENV.PRODUCT_PRICE || '1000');
+
+const ZOOM_START = parseInt(__ENV.ZOOM_START || '100');
+const ZOOM_END   = parseInt(__ENV.ZOOM_END   || '200');
+
+// ── 이론적 근거 ──────────────────────────────────────────────────────────────
+//
+//  HikariCP pool=10, connection-timeout=3000ms
+//  MockTossPaymentClient: 100~500ms random (avg ≈ 300ms)
+//
+//  [Before] @Transactional이 외부 호출 포함 전체를 감쌈
+//    커넥션 점유 시간 ≈ DB조회(5ms) + HTTP validate(5ms) + PG호출(300ms) + DB저장(5ms) ≈ 315ms
+//
+//    포화점 VU  = pool × 점유시간 = 10 × (1 / 0.315s) → 역산: 10 × 0.315 ≈ 10VU  ← pool 100%
+//    timeout VU = 포화점 + (3000ms / 31.5ms) ≈ 107VU                               ← 실패 시작
+//
+//    VU=10  대기 0ms     pool 정확히 포화, 기준선
+//    VU=50  대기 1,240ms timeout 없음, latency 증가
+//    VU=100 대기 2,790ms timeout 직전
+//    VU=200 대기 5,890ms timeout 발생 구간
+//    VU=500 대기 15,190ms 거의 전부 실패
+//
+//  [After] 외부 호출 중 커넥션 미점유
+//    커넥션 점유 시간 ≈ 2ms → 이론 max TPS ≈ 5,000 → 모든 단계에서 안정적이어야 함
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+// scan VU: 기본값 [10,50,100,200,500], env로 덮어쓰기 가능
+// 예) -e SCAN_VUS=500,750,1000,1500,2000
+const SCAN_VUS = (__ENV.SCAN_VUS || '10,50,100,200,500')
+  .split(',')
+  .map(v => parseInt(v.trim()));
+
+// zoom: ZOOM_START~ZOOM_END 를 5등분 (양 끝 포함)
+function buildZoomVUs() {
+  const steps    = 5;
+  const interval = Math.round((ZOOM_END - ZOOM_START) / (steps - 1));
+  const vus = [];
+  for (let i = 0; i < steps - 1; i++) {
+    vus.push(ZOOM_START + interval * i);
+  }
+  vus.push(ZOOM_END);
+  return vus;
+}
+
+function buildStages() {
+  if (STAGE === 'scan') {
+    // 각 VU 단계: 10s 램프 → 45s 유지
+    // 총 소요: (10s + 45s) × 5 + 10s(쿨다운) ≈ 5분
+    const stages = [];
+    for (const vu of SCAN_VUS) {
+      stages.push({ duration: '10s', target: vu });
+      stages.push({ duration: '45s', target: vu });
+    }
+    stages.push({ duration: '10s', target: 0 });
+    return stages;
+  }
+
+  if (STAGE === 'zoom') {
+    // 각 VU 단계: 10s 램프 → 50s 유지 (정밀 측정)
+    // 총 소요: (10s + 50s) × 5 + 10s(쿨다운) ≈ 5분
+    const stages = [];
+    for (const vu of buildZoomVUs()) {
+      stages.push({ duration: '10s', target: vu });
+      stages.push({ duration: '50s', target: vu });
+    }
+    stages.push({ duration: '10s', target: 0 });
+    return stages;
+  }
+
+  // 개별 단계 실행 (레거시 호환)
+  const legacyMap = {
+    smoke:  { vus: 3,   duration: '30s' },
+    load:   { vus: 30,  duration: '1m'  },
+    stress: { vus: 150, duration: '2m'  },
+  };
+  const s = legacyMap[STAGE];
+  if (!s) throw new Error(`알 수 없는 STAGE: ${STAGE}`);
+  return [
+    { duration: '10s',       target: s.vus },
+    { duration: s.duration,  target: s.vus },
+    { duration: '10s',       target: 0     },
+  ];
+}
+
+// ── thresholds ────────────────────────────────────────────────────────────────
+//
+//  scan: 실패 예상 구간(VU=200,500) 포함 → pass/fail 기준 무의미, 관찰용으로 느슨하게
+//  zoom: 정밀 측정 목적 → threshold 없음, 숫자 자체를 분석
+//
+// ─────────────────────────────────────────────────────────────────────────────
+const THRESHOLDS = {
+  scan:   { http_req_duration: ['p(95)<5000'], http_req_failed: ['rate<0.9'] },
+  zoom:   {},
+  smoke:  { http_req_duration: ['p(95)<5000'], http_req_failed: ['rate<0.1'] },
+  load:   { http_req_duration: ['p(95)<5000'], http_req_failed: ['rate<0.1'] },
+  stress: { http_req_duration: ['p(95)<5000'], http_req_failed: ['rate<0.1'] },
+};
+
+export const options = {
+  stages:     buildStages(),
+  thresholds: THRESHOLDS[STAGE] || {},
+};
+
+// ── setup: 테스트 데이터 준비 ──────────────────────────────────────────────────
+//
+//  setup count 근거:
+//
+//  scan (400개):
+//    VU=500이 최대, 매 순간 pool=10개 row를 동시에 읽음
+//    row 다양성 부족 → 동일 row 집중 → 비정상적 lock/cache 패턴
+//    최소 필요: pool × 다양성 배율(10배) = 100개
+//    여유분 4배 적용: 400개 (setup 소요 약 80초)
+//
+//  zoom (min(ZOOM_END×2, 150)개):
+//    탐색 VU 범위가 좁음 (예: 100~200)
+//    confirmPerfBefore/After는 Payment 상태를 바꾸지 않아 동일 orderId 재사용 가능
+//    ZOOM_END=200 기준 max 150개로 충분
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+function getSetupCount() {
+  if (STAGE === 'scan') return 400;
+  if (STAGE === 'zoom') return Math.min(ZOOM_END * 2, 150);
+  return 50;
+}
+
+export function setup() {
+  const res = http.post(`${BASE_URL}/api/v1/auth/login`, JSON.stringify({
+    email:    EMAIL,
+    password: PASSWORD,
+  }), { headers: { 'Content-Type': 'application/json' } });
+
+  const token = res.json('data.accessToken');
+  if (!token) {
+    throw new Error(`로그인 실패 — status=${res.status} body=${res.body}`);
+  }
+
+  const count = getSetupCount();
+  console.log(`[setup] 로그인 성공 | scenario=${SCENARIO} stage=${STAGE} | 주문 ${count}개 생성 시작...`);
+
+  const orders = [];
+  for (let i = 0; i < count; i++) {
+    const orderId = createOrder(token);
+    if (!orderId) continue;
+
+    preparePayment(token, orderId);
+    orders.push(orderId);
+
+    if ((i + 1) % 50 === 0) {
+      console.log(`[setup] ${i + 1}/${count} 완료`);
+    }
+  }
+
+  console.log(`[setup] 완료 — ${orders.length}개 준비됨`);
+  return { token, orders };
+}
+
+export default function (data) {
+  const headers = {
+    Authorization:  `Bearer ${data.token}`,
+    'Content-Type': 'application/json',
+  };
+
+  const idx     = (__VU - 1) * 100 + __ITER;
+  const orderId = data.orders[idx % data.orders.length];
+  const endpoint = SCENARIO === 'before'
+    ? `${BASE_URL}/api/v1/payments/perf/confirm/before`
+    : `${BASE_URL}/api/v1/payments/perf/confirm/after`;
+
+  const res = http.post(endpoint, JSON.stringify({
+    orderId:    orderId,
+    paymentKey: 'perf-key',
+    amount:     PRODUCT_PRICE,
+  }), { headers });
+
+  if (res.status !== 200) {
+    console.error(`[confirm] 실패 status=${res.status} body=${res.body}`);
+  }
+
+  check(res, {
+    'status 200': (r) => r.status === 200,
+    'p95 < 3s':   (r) => r.timings.duration < 3000,
+  });
+}
+
+// ── 헬퍼 ────────────────────────────────────────────────────────────────────
+
+function createOrder(token) {
+  const res = http.post(`${BASE_URL}/api/v1/orders`, JSON.stringify({
+    productId:         PRODUCT_ID,
+    productScheduleId: PRODUCT_SCHEDULE_ID,
+    quantity:          1,
+    productPrice:      PRODUCT_PRICE,
+    depositAmount:     0,
+  }), {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization:  `Bearer ${token}`,
+    },
+  });
+
+  if (res.status !== 201) {
+    console.error(`[createOrder] 실패 status=${res.status} body=${res.body}`);
+    return null;
+  }
+  const orderId = res.json('id');
+  if (!orderId) {
+    console.error(`[createOrder] orderId 파싱 실패 body=${res.body}`);
+  }
+  return orderId;
+}
+
+function preparePayment(token, orderId) {
+  const res = http.post(`${BASE_URL}/api/v1/payments/prepare`, JSON.stringify({
+    orderId:       orderId,
+    productId:     PRODUCT_ID,
+    paymentMethod: 'TOSS',
+    paymentAmount: PRODUCT_PRICE,
+    depositAmount: 0,
+  }), {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization:  `Bearer ${token}`,
+    },
+  });
+
+  if (res.status !== 200 && res.status !== 201) {
+    console.error(`[preparePayment] 실패 status=${res.status} body=${res.body}`);
+  }
+}

--- a/monitoring/grafana/provisioning/datasources/datasource.yaml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yaml
@@ -1,0 +1,27 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    jsonData:
+      timeInterval: 15s
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    url: http://tempo:3200
+    jsonData:
+      tracesToMetricsV2:
+        datasourceUid: prometheus
+        tags:
+          - key: service.name
+            value: application
+      serviceMap:
+        datasourceUid: prometheus
+      nodeGraph:
+        enabled: true
+      search:
+        hide: false

--- a/monitoring/tempo/tempo.yaml
+++ b/monitoring/tempo/tempo.yaml
@@ -1,0 +1,24 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    zipkin:
+
+ingester:
+  trace_idle_period: 10s
+  max_block_bytes: 1_000_000
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    compaction_window: 1h
+    max_compaction_objects: 1000000
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /tmp/tempo/blocks
+    wal:
+      path: /tmp/tempo/wal

--- a/service/admin/build.gradle
+++ b/service/admin/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
     implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/service/admin/src/main/resources/application-dev.yml
+++ b/service/admin/src/main/resources/application-dev.yml
@@ -14,3 +14,11 @@ logging:
     org.springframework.web: DEBUG
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://tempo:9411/api/v2/spans

--- a/service/ai/build.gradle
+++ b/service/ai/build.gradle
@@ -52,6 +52,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 }
 
 tasks.named('test') {

--- a/service/ai/src/main/resources/application-dev.yml
+++ b/service/ai/src/main/resources/application-dev.yml
@@ -16,3 +16,11 @@ spring:
     redis:
       host: localhost
       port: 6380
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://tempo:9411/api/v2/spans

--- a/service/order/build.gradle
+++ b/service/order/build.gradle
@@ -40,6 +40,9 @@ implementation 'org.springframework.kafka:spring-kafka'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    implementation 'io.zipkin.reporter2:zipkin-sender-urlconnection'
 }
 
 tasks.named('test') {

--- a/service/order/src/main/java/jabaclass/order/common/config/TracingConfig.java
+++ b/service/order/src/main/java/jabaclass/order/common/config/TracingConfig.java
@@ -1,0 +1,81 @@
+package jabaclass.order.common.config;
+
+import brave.Tracing;
+import brave.handler.SpanHandler;
+import brave.sampler.Sampler;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
+import io.micrometer.tracing.brave.bridge.BravePropagator;
+import io.micrometer.tracing.brave.bridge.BraveTracer;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
+import io.micrometer.tracing.handler.PropagatingSenderTracingObservationHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.micrometer.observation.autoconfigure.ObservationRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
+
+@Configuration
+public class TracingConfig {
+
+    @Value("${management.zipkin.tracing.endpoint:http://localhost:9411/api/v2/spans}")
+    private String zipkinEndpoint;
+
+    @Value("${spring.application.name:order}")
+    private String serviceName;
+
+    @Bean(destroyMethod = "close")
+    public BytesMessageSender zipkinSender() {
+        return URLConnectionSender.create(zipkinEndpoint);
+    }
+
+    @Bean(destroyMethod = "close")
+    public SpanHandler zipkinSpanHandler(BytesMessageSender sender) {
+        return AsyncZipkinSpanHandler.create(sender);
+    }
+
+    @Bean(destroyMethod = "close")
+    public Tracing braveTracing(SpanHandler spanHandler) {
+        return Tracing.newBuilder()
+                .localServiceName(serviceName)
+                .addSpanHandler(spanHandler)
+                .sampler(Sampler.ALWAYS_SAMPLE)
+                .build();
+    }
+
+    @Bean
+    public brave.Tracer braveNativeTracer(Tracing tracing) {
+        return tracing.tracer();
+    }
+
+    @Bean
+    public BraveCurrentTraceContext braveCurrentTraceContext(Tracing tracing) {
+        return new BraveCurrentTraceContext(tracing.currentTraceContext());
+    }
+
+    @Bean
+    public BravePropagator bravePropagator(Tracing tracing) {
+        return new BravePropagator(tracing);
+    }
+
+    @Bean
+    public BraveTracer micrometerTracer(brave.Tracer tracer, BraveCurrentTraceContext currentTraceContext) {
+        return new BraveTracer(tracer, currentTraceContext);
+    }
+
+    @Bean
+    public ObservationRegistryCustomizer<ObservationRegistry> tracingCustomizer(
+            BraveTracer tracer,
+            BravePropagator propagator) {
+        return registry -> registry.observationConfig()
+                .observationHandler(new ObservationHandler.FirstMatchingCompositeObservationHandler(
+                        new PropagatingReceiverTracingObservationHandler<>(tracer, propagator),
+                        new PropagatingSenderTracingObservationHandler<>(tracer, propagator),
+                        new DefaultTracingObservationHandler(tracer)
+                ));
+    }
+}

--- a/service/order/src/main/resources/application-dev.yml
+++ b/service/order/src/main/resources/application-dev.yml
@@ -23,3 +23,10 @@ logging:
   level:
     jabaclass: DEBUG
     org.springframework.web: DEBUG
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://tempo:9411/api/v2/spans

--- a/service/payment/build.gradle
+++ b/service/payment/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    implementation 'io.zipkin.reporter2:zipkin-sender-urlconnection'
 }
 
 tasks.named('test') {

--- a/service/payment/src/main/java/jabaclass/payment/application/service/PaymentPerfSimService.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/PaymentPerfSimService.java
@@ -1,0 +1,71 @@
+package jabaclass.payment.application.service;
+
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.payment.application.port.external.OrderPort;
+import jabaclass.payment.application.port.external.PaymentGatewayPort;
+import jabaclass.payment.common.error.PaymentErrorCode;
+import jabaclass.payment.common.error.PaymentException;
+import jabaclass.payment.domain.model.Payment;
+import jabaclass.payment.domain.repository.PaymentRepository;
+import jabaclass.payment.presentation.dto.request.ConfirmPaymentRequestDto;
+import jabaclass.payment.presentation.dto.response.PaymentResponseDto;
+
+@Service
+public class PaymentPerfSimService {
+
+	private final JdbcTemplate jdbcTemplate;
+	private final PaymentRepository paymentRepository;
+	private final PaymentGatewayPort mockGateway;
+	private final OrderPort orderPort;
+
+	public PaymentPerfSimService(
+		JdbcTemplate jdbcTemplate,
+		PaymentRepository paymentRepository,
+		@Qualifier("mockTossPaymentClient") PaymentGatewayPort mockGateway,
+		OrderPort orderPort
+	) {
+		this.jdbcTemplate = jdbcTemplate;
+		this.paymentRepository = paymentRepository;
+		this.mockGateway = mockGateway;
+		this.orderPort = orderPort;
+	}
+
+	// Before: @Transactional이 order 검증 + Mock PG 호출 전체를 감쌈 → 커넥션 ~300ms 점유
+	@Transactional
+	public PaymentResponseDto confirmPerfBefore(UUID userId, ConfirmPaymentRequestDto request) {
+		Payment payment = paymentRepository.findByOrderId(request.orderId())
+			.orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+		if (!payment.getUserId().equals(userId)) {
+			throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_PAYMENT_ACCESS);
+		}
+
+		orderPort.validateOrder(request.orderId(), request.amount());
+		mockGateway.confirm(request.paymentKey(), payment.getOrderId().toString(), request.amount());
+
+		return PaymentResponseDto.from(payment);
+	}
+
+	// After: @Transactional 없음 → order 검증/PG 호출 중 커넥션 미점유
+	public PaymentResponseDto confirmPerfAfter(UUID userId, ConfirmPaymentRequestDto request) {
+		Payment payment = paymentRepository.findByOrderId(request.orderId())
+			.orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+		if (!payment.getUserId().equals(userId)) {
+			throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_PAYMENT_ACCESS);
+		}
+
+		orderPort.validateOrder(request.orderId(), request.amount());
+		mockGateway.confirm(request.paymentKey(), payment.getOrderId().toString(), request.amount());
+
+		jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+
+		return PaymentResponseDto.from(payment);
+	}
+}

--- a/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
+++ b/service/payment/src/main/java/jabaclass/payment/application/service/PaymentService.java
@@ -138,6 +138,71 @@ public class PaymentService implements PaymentUseCase, PaymentSettlementQueryUse
 		}
 	}
 
+	// [성능 테스트 Before] @Transactional로 PG 호출 포함 전체 감쌈 → DB 커넥션을 PG 응답 대기 중에도 점유
+	// gateway를 주입받아 MockTossPaymentClient 사용 가능 — perf 프로파일 없이도 실 Toss와 동시 운영 가능
+	@Transactional
+	public PaymentResponseDto confirmBefore(UUID userId, ConfirmPaymentRequestDto request, PaymentGatewayPort gateway) {
+		Payment payment = paymentRepository.findByOrderId(request.orderId())
+			.orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+		if (!payment.getUserId().equals(userId)) {
+			throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_PAYMENT_ACCESS);
+		}
+
+		if (payment.isDone()) {
+			return PaymentResponseDto.from(payment);
+		}
+
+		boolean valid = orderPort.validateOrder(payment.getOrderId(), payment.getTotalAmount().intValue());
+		if (!valid) {
+			throw new PaymentException(PaymentErrorCode.INVALID_ORDER_AMOUNT);
+		}
+
+		if (payment.getPaymentAmount().compareTo(BigDecimal.valueOf(request.amount())) != 0) {
+			throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_AMOUNT);
+		}
+
+		try {
+			gateway.confirm(request.paymentKey(), payment.getOrderId().toString(), request.amount());
+			return paymentConfirmHandler.onSuccess(payment.getId(), request.paymentKey());
+		} catch (Exception e) {
+			paymentConfirmHandler.onFailure(payment.getId(), payment.getOrderId(), payment.getDepositAmount());
+			throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED, e);
+		}
+	}
+
+	// [성능 테스트 After] @Transactional 없음 — PG 호출 대기 중 커넥션 미점유
+	// confirm()과 동일한 구조지만 gateway를 주입받아 MockTossPaymentClient 사용 가능
+	public PaymentResponseDto confirmAfterWithMock(UUID userId, ConfirmPaymentRequestDto request, PaymentGatewayPort gateway) {
+		Payment payment = paymentRepository.findByOrderId(request.orderId())
+			.orElseThrow(() -> new PaymentException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+		if (!payment.getUserId().equals(userId)) {
+			throw new PaymentException(PaymentErrorCode.UNAUTHORIZED_PAYMENT_ACCESS);
+		}
+
+		if (payment.isDone()) {
+			return PaymentResponseDto.from(payment);
+		}
+
+		boolean valid = orderPort.validateOrder(payment.getOrderId(), payment.getTotalAmount().intValue());
+		if (!valid) {
+			throw new PaymentException(PaymentErrorCode.INVALID_ORDER_AMOUNT);
+		}
+
+		if (payment.getPaymentAmount().compareTo(BigDecimal.valueOf(request.amount())) != 0) {
+			throw new PaymentException(PaymentErrorCode.INVALID_PAYMENT_AMOUNT);
+		}
+
+		try {
+			gateway.confirm(request.paymentKey(), payment.getOrderId().toString(), request.amount());
+			return paymentConfirmHandler.onSuccess(payment.getId(), request.paymentKey());
+		} catch (Exception e) {
+			paymentConfirmHandler.onFailure(payment.getId(), payment.getOrderId(), payment.getDepositAmount());
+			throw new PaymentException(PaymentErrorCode.PAYMENT_CONFIRM_FAILED, e);
+		}
+	}
+
 	// [오케스트레이터] Order 서비스의 동기 HTTP 호출로 진입 — @Transactional 없음
 	// PG 환불 실패 시 예외를 Order로 전파 → Order가 PAID 상태 유지 (보상 불필요)
 	// PG 성공 후 DB 저장 실패는 알려진 한계 — 웹훅/정합성 배치로 별도 복구

--- a/service/payment/src/main/java/jabaclass/payment/config/RestTemplateConfig.java
+++ b/service/payment/src/main/java/jabaclass/payment/config/RestTemplateConfig.java
@@ -1,5 +1,6 @@
 package jabaclass.payment.config;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
@@ -8,7 +9,9 @@ import org.springframework.web.client.RestTemplate;
 public class RestTemplateConfig {
 
 	@Bean
-	public RestTemplate restTemplate() {
-		return new RestTemplate();
+	public RestTemplate restTemplate(ObservationRegistry observationRegistry) {
+		RestTemplate restTemplate = new RestTemplate();
+		restTemplate.setObservationRegistry(observationRegistry);
+		return restTemplate;
 	}
 }

--- a/service/payment/src/main/java/jabaclass/payment/config/TracingConfig.java
+++ b/service/payment/src/main/java/jabaclass/payment/config/TracingConfig.java
@@ -1,0 +1,81 @@
+package jabaclass.payment.config;
+
+import brave.Tracing;
+import brave.handler.SpanHandler;
+import brave.sampler.Sampler;
+import io.micrometer.observation.ObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.boot.micrometer.observation.autoconfigure.ObservationRegistryCustomizer;
+import io.micrometer.tracing.brave.bridge.BraveCurrentTraceContext;
+import io.micrometer.tracing.brave.bridge.BravePropagator;
+import io.micrometer.tracing.brave.bridge.BraveTracer;
+import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
+import io.micrometer.tracing.handler.PropagatingReceiverTracingObservationHandler;
+import io.micrometer.tracing.handler.PropagatingSenderTracingObservationHandler;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import zipkin2.reporter.BytesMessageSender;
+import zipkin2.reporter.brave.AsyncZipkinSpanHandler;
+import zipkin2.reporter.urlconnection.URLConnectionSender;
+
+@Configuration
+public class TracingConfig {
+
+    @Value("${management.zipkin.tracing.endpoint:http://localhost:9411/api/v2/spans}")
+    private String zipkinEndpoint;
+
+    @Value("${spring.application.name:payment}")
+    private String serviceName;
+
+    @Bean(destroyMethod = "close")
+    public BytesMessageSender zipkinSender() {
+        return URLConnectionSender.create(zipkinEndpoint);
+    }
+
+    @Bean(destroyMethod = "close")
+    public SpanHandler zipkinSpanHandler(BytesMessageSender sender) {
+        return AsyncZipkinSpanHandler.create(sender);
+    }
+
+    @Bean(destroyMethod = "close")
+    public Tracing braveTracing(SpanHandler spanHandler) {
+        return Tracing.newBuilder()
+                .localServiceName(serviceName)
+                .addSpanHandler(spanHandler)
+                .sampler(Sampler.ALWAYS_SAMPLE)
+                .build();
+    }
+
+    @Bean
+    public brave.Tracer braveNativeTracer(Tracing tracing) {
+        return tracing.tracer();
+    }
+
+    @Bean
+    public BraveCurrentTraceContext braveCurrentTraceContext(Tracing tracing) {
+        return new BraveCurrentTraceContext(tracing.currentTraceContext());
+    }
+
+    @Bean
+    public BravePropagator bravePropagator(Tracing tracing) {
+        return new BravePropagator(tracing);
+    }
+
+    @Bean
+    public BraveTracer micrometerTracer(brave.Tracer tracer, BraveCurrentTraceContext currentTraceContext) {
+        return new BraveTracer(tracer, currentTraceContext);
+    }
+
+    @Bean
+    public ObservationRegistryCustomizer<ObservationRegistry> tracingCustomizer(
+            BraveTracer tracer,
+            BravePropagator propagator) {
+        return registry -> registry.observationConfig()
+                .observationHandler(new ObservationHandler.FirstMatchingCompositeObservationHandler(
+                        new PropagatingReceiverTracingObservationHandler<>(tracer, propagator),
+                        new PropagatingSenderTracingObservationHandler<>(tracer, propagator),
+                        new DefaultTracingObservationHandler(tracer)
+                ));
+    }
+}

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/external/toss/MockTossPaymentClient.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/external/toss/MockTossPaymentClient.java
@@ -1,0 +1,53 @@
+package jabaclass.payment.infrastructure.external.toss;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.springframework.stereotype.Component;
+
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import jabaclass.payment.application.port.external.PaymentGatewayPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component("mockTossPaymentClient")
+@RequiredArgsConstructor
+public class MockTossPaymentClient implements PaymentGatewayPort {
+
+	// Toss Payments API 실측 기준: P50=230ms, P95=440ms, 범위 100~500ms
+	private static final int MIN_DELAY_MS = 100;
+	private static final int MAX_DELAY_MS = 500;
+
+	private final ObservationRegistry observationRegistry;
+
+	@Override
+	public void confirm(String paymentKey, String orderId, int amount) {
+		Observation.createNotStarted("toss.pg.confirm", observationRegistry)
+			.lowCardinalityKeyValue("pg", "toss")
+			.observe(() -> {
+				long delay = networkDelay();
+				log.info("[MockToss] confirm 완료. orderId={}, amount={}, delay={}ms", orderId, amount, delay);
+			});
+	}
+
+	@Override
+	public void refund(String paymentKey, int cancelAmount, String idempotencyKey) {
+		Observation.createNotStarted("toss.pg.refund", observationRegistry)
+			.lowCardinalityKeyValue("pg", "toss")
+			.observe(() -> {
+				long delay = networkDelay();
+				log.info("[MockToss] refund 완료. cancelAmount={}, delay={}ms", cancelAmount, delay);
+			});
+	}
+
+	private long networkDelay() {
+		long delay = ThreadLocalRandom.current().nextLong(MIN_DELAY_MS, MAX_DELAY_MS + 1);
+		try {
+			Thread.sleep(delay);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+		return delay;
+	}
+}

--- a/service/payment/src/main/java/jabaclass/payment/infrastructure/external/toss/TossPaymentClient.java
+++ b/service/payment/src/main/java/jabaclass/payment/infrastructure/external/toss/TossPaymentClient.java
@@ -3,6 +3,7 @@ package jabaclass.payment.infrastructure.external.toss;
 import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -13,6 +14,7 @@ import org.springframework.web.client.RestTemplate;
 import jabaclass.payment.application.port.external.PaymentGatewayPort;
 import lombok.RequiredArgsConstructor;
 
+@Primary
 @Component
 @RequiredArgsConstructor
 public class TossPaymentClient implements PaymentGatewayPort {

--- a/service/payment/src/main/java/jabaclass/payment/presentation/controller/PaymentPerfController.java
+++ b/service/payment/src/main/java/jabaclass/payment/presentation/controller/PaymentPerfController.java
@@ -1,0 +1,53 @@
+package jabaclass.payment.presentation.controller;
+
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jabaclass.payment.application.service.PaymentPerfSimService;
+import jabaclass.payment.common.auth.CurrentUser;
+import jabaclass.payment.common.dto.ApiResponseDto;
+import jabaclass.payment.presentation.dto.request.ConfirmPaymentRequestDto;
+import jabaclass.payment.presentation.dto.response.PaymentResponseDto;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 성능 테스트 전용 컨트롤러
+ *
+ * [실제 결제 흐름 기반 — setup()에서 주문+결제 사전 생성 필요]
+ * POST /perf/confirm/before  — @Transactional이 Mock PG 호출 포함, 커넥션 ~300ms 점유
+ * POST /perf/confirm/after   — 트랜잭션 분리, PG 호출 중 커넥션 미점유
+ *
+ * [순수 커넥션 풀 시뮬레이션 — DB 레코드 불필요]
+ * POST /perf/sim/before  — 커넥션 획득 후 300ms 점유
+ * POST /perf/sim/after   — 300ms 대기 후 커넥션 잠깐 사용
+ */
+@RestController
+@RequestMapping("/api/v1/payments/perf")
+@RequiredArgsConstructor
+public class PaymentPerfController {
+
+	private final PaymentPerfSimService paymentPerfSimService;
+
+	@PostMapping("/confirm/before")
+	public ResponseEntity<ApiResponseDto<PaymentResponseDto>> confirmBefore(
+		@RequestBody ConfirmPaymentRequestDto request,
+		@CurrentUser UUID userId) {
+		PaymentResponseDto response = paymentPerfSimService.confirmPerfBefore(userId, request);
+		return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, "perf confirm before", response));
+	}
+
+	@PostMapping("/confirm/after")
+	public ResponseEntity<ApiResponseDto<PaymentResponseDto>> confirmAfter(
+		@RequestBody ConfirmPaymentRequestDto request,
+		@CurrentUser UUID userId) {
+		PaymentResponseDto response = paymentPerfSimService.confirmPerfAfter(userId, request);
+		return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, "perf confirm after", response));
+	}
+
+}

--- a/service/payment/src/main/resources/application-dev.yml
+++ b/service/payment/src/main/resources/application-dev.yml
@@ -4,8 +4,21 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USER:root}
     password: ${MYSQL_PASSWORD:1234}
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 3000
+      idle-timeout: 600000
 
   jpa:
+    open-in-view: false
     hibernate:
       ddl-auto: update
     show-sql: false
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://tempo:9411/api/v2/spans

--- a/service/product/build.gradle
+++ b/service/product/build.gradle
@@ -41,6 +41,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
 
     implementation platform('software.amazon.awssdk:bom:2.25.0')

--- a/service/product/src/main/java/jabaclass/product/application/service/ScheduleService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ScheduleService.java
@@ -165,7 +165,7 @@ public class ScheduleService implements ScheduleUseCase {
 		Product product = productUseCase.findByIdOrThrow(schedule.getProductId());
 
 		// 가격 검증 => 실패의 경우
-		if (!product.getPrice().equals(requestDto.price())) {
+		if (product.getPrice().compareTo(requestDto.price()) != 0) {
 			return OrderResponseDto.from(product, requestDto.quantity(), OrderValid.PRICE_MISMATCH, null);
 		}
 

--- a/service/product/src/main/resources/application-dev.yml
+++ b/service/product/src/main/resources/application-dev.yml
@@ -44,3 +44,11 @@ logging:
   level:
     org.hibernate.SQL: WARN
     org.hibernate.type.descriptor.sql: WARN
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://tempo:9411/api/v2/spans

--- a/service/settlement/build.gradle
+++ b/service/settlement/build.gradle
@@ -59,6 +59,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 }
 
 tasks.named('test') {

--- a/service/settlement/src/main/resources/application-dev.yml
+++ b/service/settlement/src/main/resources/application-dev.yml
@@ -21,3 +21,11 @@ settlement:
     transfer:
       cron: "30 */3 * * * *"
       target-month-offset-months: 0
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://tempo:9411/api/v2/spans

--- a/service/user/build.gradle
+++ b/service/user/build.gradle
@@ -74,6 +74,8 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
 
     // OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/service/user/src/main/resources/application-dev.yml
+++ b/service/user/src/main/resources/application-dev.yml
@@ -102,3 +102,11 @@ cookie:
 
 oauth2:
   redirect-uri: ${OAUTH2_REDIRECT_URI:http://localhost:3000/oauth2/callback}
+
+management:
+  tracing:
+    sampling:
+      probability: 1.0
+  zipkin:
+    tracing:
+      endpoint: http://tempo:9411/api/v2/spans


### PR DESCRIPTION
## 관련 이슈
- Close #6 

## 변경 요약
- 커넥션 풀 고갈 문제를 재현하기 위한 성능 테스트 엔드포인트를 추가했습니다.
- 외부 PG 호출 위치에 따른 before/after 성능 비교를 진행했습니다.
- 트랜잭션 분리를 통해 DB 커넥션 점유 시간을 줄였습니다.

## 주요 변경점
- MockTossPaymentClient를 통해 100~500ms 랜덤 지연이 있는 외부 PG 호출을 시뮬레이션했습니다.
- `/perf/confirm/before`, `/perf/confirm/after` 성능 테스트용 결제 승인 엔드포인트를 추가했습니다.
  - before: `@Transactional` 내부에서 외부 PG 호출 수행
  - after: 외부 PG 호출과 DB 트랜잭션 분리
- 개발 환경에서 커넥션 풀 병목을 관찰할 수 있도록 설정을 조정했습니다.
  - HikariCP pool-size=10
  - connection-timeout=3000ms

## 성능 테스트 결과
- Before
  - 실패율: 26.30%
  - p95 응답 시간: 8.01s
  - 안정 TPS: 약 32
  - 약 100 VU 이후 HikariCP timeout 발생

- After
  - 실패율: 0%
  - p95 응답 시간: 911ms
  - 안정 TPS: 약 637+
  - 2000 VU 구간에서도 timeout 없이 처리 확인

## 개선 효과
- 원인: `@Transactional` 내부에서 외부 PG 호출을 수행하면서 DB 커넥션을 오래 점유
- 개선: 외부 PG 호출을 트랜잭션 밖으로 분리
- 결과: 커넥션 점유 시간이 약 315ms에서 약 7ms 수준으로 감소

## 테스트
- [x] k6 부하 테스트 실행