### PR TITLE
refactor: 상품 카테고리, 지역 필터 기반 조회 인덱스 최적화

### DIFF
--- a/k6/product-index-comparison.js
+++ b/k6/product-index-comparison.js
@@ -1,0 +1,96 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+/**
+ * 복합 인덱스 Before/After TPS 비교 테스트
+ *
+ * [사용법]
+ *
+ * Step 1 — 인덱스 없는 상태에서 측정 (Workbench에서 인덱스 DROP 후 실행)
+ *   k6 run -e SCENARIO=no_index k6/product-index-comparison.js
+ *
+ * Step 2 — 복합 인덱스 추가 후 측정
+ *   CREATE INDEX idx_category_region ON products (category, region, status, delete_dt, reg_dt);
+ *   k6 run -e SCENARIO=composite_index k6/product-index-comparison.js
+ *
+ * Step 3 — (선택) 커버링 인덱스 비교
+ *   DROP INDEX idx_category_region ON products;
+ *   CREATE INDEX idx_covering ON products (category, region, status, delete_dt, reg_dt, id, title, price, thumbnail_path);
+ *   k6 run -e SCENARIO=covering_index k6/product-index-comparison.js
+ *
+ * [환경변수]
+ *   BASE_URL  : 기본값 http://localhost:9004
+ *   SCENARIO  : no_index | composite_index | covering_index (레이블용, 실제 동작은 동일)
+ *   CATEGORY  : 필터 카테고리 (기본값 SPORTS)
+ *   REGION    : 필터 지역     (기본값 GANGNAM)
+ *   PAGE      : 페이지 번호   (기본값 0)
+ *   SIZE      : 페이지 크기   (기본값 10)
+ */
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:9004';
+const SCENARIO = __ENV.SCENARIO || 'no_index';
+const CATEGORY = __ENV.CATEGORY || 'SPORTS';
+const REGION   = __ENV.REGION   || 'GANGNAM';
+const PAGE     = __ENV.PAGE     || '0';
+const SIZE     = __ENV.SIZE     || '10';
+
+// ── 이론적 근거 ──────────────────────────────────────────────────────────────
+//
+//  products 테이블: 500만 건 (category 5종 × region 25개 × 40,000건)
+//
+//  [no_index]
+//    type=ALL → Full Table Scan (5,000,000 rows)
+//    Extra=Using filesort → 정렬 추가 비용
+//    예상: 단일 쿼리 수백ms~수초 → 낮은 TPS
+//
+//  [composite_index] idx_category_region (category, region, status, delete_dt, reg_dt)
+//    type=ref → B-Tree Range Scan (~40,000 rows → LIMIT 10으로 조기 종료)
+//    Extra=Backward index scan → reg_dt DESC 정렬을 인덱스에서 직접 처리
+//    예상: 단일 쿼리 수ms → 높은 TPS
+//
+//  [covering_index] + (id, title, price, thumbnail_path)
+//    Extra=Using index → heap lookup 제거
+//    이론: composite_index 대비 10~20% 추가 향상 (heap 접근 제거)
+//    트레이드오프: 인덱스 크기 ~3배 증가 → 쓰기 오버헤드 증가
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+// VU 단계: 1 → 5 → 10 → 30 → 50 → 100
+// no_index는 50 이상에서 timeout 예상, composite_index는 100에서도 안정적이어야 함
+export const options = {
+  stages: [
+    { duration: '10s', target: 1   },  // warm-up
+    { duration: '30s', target: 1   },  // baseline
+    { duration: '10s', target: 5   },
+    { duration: '30s', target: 5   },
+    { duration: '10s', target: 10  },
+    { duration: '30s', target: 10  },
+    { duration: '10s', target: 30  },
+    { duration: '30s', target: 30  },
+    { duration: '10s', target: 50  },
+    { duration: '30s', target: 50  },
+    { duration: '10s', target: 100 },
+    { duration: '30s', target: 100 },
+    { duration: '10s', target: 0   },  // cool-down
+  ],
+  thresholds: {
+    // no_index: 완전한 실패 기준만 (관찰용)
+    // composite_index: p95 < 500ms 기대
+    http_req_failed:   ['rate<0.5'],
+    http_req_duration: ['p(99)<30000'],
+  },
+};
+
+const URL = `${BASE_URL}/api/v1/products/filter?category=${CATEGORY}&region=${REGION}&page=${PAGE}&size=${SIZE}`;
+
+export default function () {
+  const res = http.get(URL, {
+    tags: { scenario: SCENARIO },
+  });
+
+  check(res, {
+    'status 200':    (r) => r.status === 200,
+    'p95 < 500ms':   (r) => r.timings.duration < 500,
+    'p95 < 3000ms':  (r) => r.timings.duration < 3000,
+  });
+}

--- a/service/product/build.gradle
+++ b/service/product/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     implementation platform('software.amazon.awssdk:bom:2.25.0')
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:s3-transfer-manager'
+
+    implementation 'com.github.f4b6a3:uuid-creator:6.0.0'
 }
 
 tasks.named('test') {

--- a/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jabaclass.product.application.acl.SellerRepository;
 import jabaclass.product.application.exception.BusinessException;
 import jabaclass.product.application.usecase.ProductUseCase;
+import jabaclass.product.domain.model.status.CategoryType;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.application.usecase.ValidateFileUseCase;
 import jabaclass.product.common.exception.CommonErrorCode;
 import jabaclass.product.domain.model.Product;
@@ -86,6 +88,8 @@ public class ProductService implements ProductUseCase {
 			.zonecode(requestDto.zonecode())
 			.latitude(requestDto.latitude())
 			.longitude(requestDto.longitude())
+			.category(requestDto.category())
+			.region(requestDto.region())
 			.build();
 
 		product.changeImages(images);
@@ -115,6 +119,8 @@ public class ProductService implements ProductUseCase {
 		product.changeZonecode(requestDto.zonecode());
 		product.changeLatitude(requestDto.latitude());
 		product.changeLongitude(requestDto.longitude());
+		product.changeCategory(requestDto.category());
+		product.changeRegion(requestDto.region());
 
 		// 이미지 수정 — null이면 기존 이미지 유지
 		if (requestDto.imageIds() != null) {
@@ -235,6 +241,16 @@ public class ProductService implements ProductUseCase {
 			.filter(Objects::nonNull)
 			.map(ProductSettlementItemResponseDto::from)
 			.toList();
+	}
+
+	@Override
+	public SearchProductResponseDto filterByCategoryAndRegion(CategoryType category, RegionType region, int page, int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<Product> result = productRepository.findByCategoryAndRegion(category, region, pageable);
+		List<ProductResponseDto> content = result.getContent().stream()
+			.map(p -> ProductResponseDto.from(p, ""))
+			.toList();
+		return SearchProductResponseDto.from(result, content);
 	}
 
 	@Override

--- a/service/product/src/main/java/jabaclass/product/application/usecase/ProductUseCase.java
+++ b/service/product/src/main/java/jabaclass/product/application/usecase/ProductUseCase.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.UUID;
 
 import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.status.CategoryType;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.presentation.dto.request.CreateProductRequestDto;
 import jabaclass.product.presentation.dto.request.SearchProductRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateProductRequestDto;
@@ -43,4 +45,6 @@ public interface ProductUseCase {
 	// PostgreSQL → ES 초기 마이그레이션
 	// 새 상품은 생성/수정 시점에 자동으로 ES에 색인되지만, ES 도입 이전에 이미 RDB에 쌓인 상품들은 ES에 없는 상태라 검색이 안 됨. 이걸 한 번에 밀어넣기 위한 엔드포인트
 	int migrateToEs();
+
+	SearchProductResponseDto filterByCategoryAndRegion(CategoryType category, RegionType region, int page, int size);
 }

--- a/service/product/src/main/java/jabaclass/product/domain/model/EntityBase.java
+++ b/service/product/src/main/java/jabaclass/product/domain/model/EntityBase.java
@@ -3,7 +3,7 @@ package jabaclass.product.domain.model;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
-import org.hibernate.annotations.UuidGenerator;
+import jabaclass.product.infrastructure.uuid.GeneratedUuidV7;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -25,7 +25,7 @@ import lombok.experimental.SuperBuilder;
 public abstract class EntityBase {
 
 	@Id
-	@UuidGenerator
+	@GeneratedUuidV7
 	@Column(name = "id", updatable = false, nullable = false)
 	private UUID id;
 

--- a/service/product/src/main/java/jabaclass/product/domain/model/Product.java
+++ b/service/product/src/main/java/jabaclass/product/domain/model/Product.java
@@ -9,6 +9,8 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jabaclass.product.application.exception.BusinessException;
 import jabaclass.product.common.exception.CommonErrorCode;
+import jabaclass.product.domain.model.status.CategoryType;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.model.status.ProductStatus;
 import jabaclass.product.infrastructure.converter.ProductImageItemsConverter;
 import jakarta.persistence.Column;
@@ -77,6 +79,14 @@ public class Product extends EntityBase {
 	@Column(nullable = false, precision = 10, scale = 7)
 	private BigDecimal longitude;
 
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private CategoryType category;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private RegionType region;
+
 	@PrePersist
 	public void prePersist() {
 		if (this.status == null) {
@@ -139,6 +149,14 @@ public class Product extends EntityBase {
 
 	public void changeLongitude(BigDecimal longitude) {
 		this.longitude = longitude;
+	}
+
+	public void changeCategory(CategoryType category) {
+		this.category = category;
+	}
+
+	public void changeRegion(RegionType region) {
+		this.region = region;
 	}
 
 }

--- a/service/product/src/main/java/jabaclass/product/domain/model/status/CategoryType.java
+++ b/service/product/src/main/java/jabaclass/product/domain/model/status/CategoryType.java
@@ -1,0 +1,19 @@
+package jabaclass.product.domain.model.status;
+
+public enum CategoryType {
+	SPORTS("운동/스포츠"),
+	COOKING("요리"),
+	ART("예술/공예"),
+	BEAUTY("뷰티"),
+	OTHER("기타");
+
+	private final String displayName;
+
+	CategoryType(String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/domain/model/status/RegionType.java
+++ b/service/product/src/main/java/jabaclass/product/domain/model/status/RegionType.java
@@ -1,0 +1,39 @@
+package jabaclass.product.domain.model.status;
+
+public enum RegionType {
+	GANGNAM("강남구"),
+	GANGDONG("강동구"),
+	GANGBUK("강북구"),
+	GANGSEO("강서구"),
+	GWANAK("관악구"),
+	GWANGJIN("광진구"),
+	GURO("구로구"),
+	GEUMCHEON("금천구"),
+	NOWON("노원구"),
+	DOBONG("도봉구"),
+	DONGDAEMUN("동대문구"),
+	DONGJAK("동작구"),
+	MAPO("마포구"),
+	SEODAEMUN("서대문구"),
+	SEOCHO("서초구"),
+	SEONGDONG("성동구"),
+	SEONGBUK("성북구"),
+	SONGPA("송파구"),
+	YANGCHEON("양천구"),
+	YEONGDEUNGPO("영등포구"),
+	YONGSAN("용산구"),
+	EUNPYEONG("은평구"),
+	JONGNO("종로구"),
+	JUNG("중구"),
+	JUNGNANG("중랑구");
+
+	private final String displayName;
+
+	RegionType(String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/domain/repository/ProductRepository.java
+++ b/service/product/src/main/java/jabaclass/product/domain/repository/ProductRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.status.CategoryType;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.model.status.ProductStatus;
 
 public interface ProductRepository {
@@ -33,4 +35,6 @@ public interface ProductRepository {
 
 	// ES 초기 마이그레이션용 — 삭제되지 않은 전체 상품 배치 조회
 	Page<Product> findAllByDeleteDtIsNull(Pageable pageable);
+
+	Page<Product> findByCategoryAndRegion(CategoryType category, RegionType region, Pageable pageable);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductJpaRepository.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductJpaRepository.java
@@ -7,8 +7,12 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.status.CategoryType;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.model.status.ProductStatus;
 
 public interface ProductJpaRepository extends JpaRepository<Product, UUID> {
@@ -24,4 +28,18 @@ public interface ProductJpaRepository extends JpaRepository<Product, UUID> {
 	List<Product> findAllByIdInAndDeleteDtIsNull(List<UUID> productIds);
 
 	Page<Product> findAllByDeleteDtIsNull(Pageable pageable);
+
+	@Query("""
+		SELECT p FROM Product p
+		WHERE p.category = :category
+		  AND p.region = :region
+		  AND p.status = :status
+		  AND p.deleteDt IS NULL
+		ORDER BY p.regDt DESC
+		""")
+	Page<Product> findByCategoryAndRegion(
+		@Param("category") CategoryType category,
+		@Param("region") RegionType region,
+		@Param("status") ProductStatus status,
+		Pageable pageable);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductRepositoryAdapter.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductRepositoryAdapter.java
@@ -9,6 +9,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.status.CategoryType;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.model.status.ProductStatus;
 import jabaclass.product.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -59,6 +61,11 @@ public class ProductRepositoryAdapter implements ProductRepository {
 	@Override
 	public Page<Product> findAllByDeleteDtIsNull(Pageable pageable) {
 		return productJpaRepository.findAllByDeleteDtIsNull(pageable);
+	}
+
+	@Override
+	public Page<Product> findByCategoryAndRegion(CategoryType category, RegionType region, Pageable pageable) {
+		return productJpaRepository.findByCategoryAndRegion(category, region, ProductStatus.ENABLE, pageable);
 	}
 
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/uuid/GeneratedUuidV7.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/uuid/GeneratedUuidV7.java
@@ -1,0 +1,14 @@
+package jabaclass.product.infrastructure.uuid;
+
+import org.hibernate.annotations.IdGeneratorType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@IdGeneratorType(UuidV7Generator.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface GeneratedUuidV7 {
+}

--- a/service/product/src/main/java/jabaclass/product/infrastructure/uuid/UuidV7Generator.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/uuid/UuidV7Generator.java
@@ -1,0 +1,22 @@
+package jabaclass.product.infrastructure.uuid;
+
+import com.github.f4b6a3.uuid.UuidCreator;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.generator.BeforeExecutionGenerator;
+import org.hibernate.generator.EventType;
+
+import java.util.EnumSet;
+import java.util.UUID;
+
+public class UuidV7Generator implements BeforeExecutionGenerator {
+
+	@Override
+	public UUID generate(SharedSessionContractImplementor session, Object owner, Object currentValue, EventType eventType) {
+		return UuidCreator.getTimeOrderedEpoch();
+	}
+
+	@Override
+	public EnumSet<EventType> getEventTypes() {
+		return EnumSet.of(EventType.INSERT);
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/presentation/controller/ProductRestController.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/controller/ProductRestController.java
@@ -19,9 +19,12 @@ import jabaclass.product.application.usecase.ProductUseCase;
 import jabaclass.product.application.usecase.ProductUserUseCase;
 import jabaclass.product.common.auth.CurrentUser;
 import jabaclass.product.common.exception.ApiResponseDto;
+import jabaclass.product.domain.model.status.CategoryType;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.presentation.dto.request.CreateProductRequestDto;
 import jabaclass.product.presentation.dto.request.SearchProductRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateProductRequestDto;
+import org.springframework.web.bind.annotation.RequestParam;
 import jabaclass.product.presentation.dto.response.DeleteProductResponseDto;
 import jabaclass.product.presentation.dto.response.ProductResponseDto;
 import jabaclass.product.presentation.dto.response.ProductUserResponseDto;
@@ -112,6 +115,17 @@ public class ProductRestController implements ProductOpenApi {
 
 		return ResponseEntity.ok()
 			.body(ApiResponseDto.success(HttpStatus.OK, "성공적으로 검색이 되었습니다.", response));
+	}
+
+	@GetMapping("/filter")
+	public ResponseEntity<ApiResponseDto<SearchProductResponseDto>> filterByCategoryAndRegion(
+		@RequestParam CategoryType category,
+		@RequestParam RegionType region,
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size
+	) {
+		SearchProductResponseDto response = productUseCase.filterByCategoryAndRegion(category, region, page, size);
+		return ResponseEntity.ok(ApiResponseDto.success(HttpStatus.OK, "성공적으로 조회되었습니다.", response));
 	}
 
 	@Override

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/CreateProductRequestDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/CreateProductRequestDto.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jabaclass.product.domain.model.status.CategoryType;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.model.status.ProductStatus;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -56,6 +58,14 @@ public record CreateProductRequestDto(
 
 	@NotNull(message = "경도를 입력해주세요.")
 	@Schema(description = "경도", example = "127.1110")
-	BigDecimal longitude
+	BigDecimal longitude,
+
+	@NotNull(message = "카테고리를 선택해주세요.")
+	@Schema(description = "카테고리", example = "SPORTS")
+	CategoryType category,
+
+	@NotNull(message = "지역을 선택해주세요.")
+	@Schema(description = "지역(구)", example = "GANGNAM")
+	RegionType region
 ) {
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/request/UpdateProductRequestDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/request/UpdateProductRequestDto.java
@@ -5,6 +5,8 @@ import java.util.List;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jabaclass.product.domain.model.status.CategoryType;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.model.status.ProductStatus;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -52,6 +54,14 @@ public record UpdateProductRequestDto(
 
 	@NotNull(message = "경도를 입력해주세요.")
 	@Schema(description = "경도", example = "127.1110")
-	BigDecimal longitude
+	BigDecimal longitude,
+
+	@NotNull(message = "카테고리를 선택해주세요.")
+	@Schema(description = "카테고리", example = "SPORTS")
+	CategoryType category,
+
+	@NotNull(message = "지역을 선택해주세요.")
+	@Schema(description = "지역(구)", example = "GANGNAM")
+	RegionType region
 ) {
 }

--- a/service/product/src/main/resources/index_analysis.sql
+++ b/service/product/src/main/resources/index_analysis.sql
@@ -1,0 +1,143 @@
+-- ============================================================
+-- 인덱스 단계별 분석 스크립트
+-- 순서대로 실행하며 EXPLAIN 결과 비교
+-- ============================================================
+
+-- ■ STEP 0: 현재 인덱스 확인
+SHOW INDEX FROM products;
+
+-- ■ STEP 0: BASELINE - 인덱스 없음
+-- type=ALL, rows≈5,000,000, Extra=Using filesort 확인
+EXPLAIN SELECT id, title, price, thumbnail_path, category, region, reg_dt
+FROM products
+WHERE category = 'SPORTS'
+  AND region = 'GANGNAM'
+  AND status = 'ENABLE'
+  AND delete_dt IS NULL
+ORDER BY reg_dt DESC
+LIMIT 10;
+
+-- ============================================================
+-- ■ STEP 1: 단일 인덱스 각각 추가 → index merge 확인
+-- ============================================================
+CREATE INDEX idx_category ON products (category);
+CREATE INDEX idx_region   ON products (region);
+
+-- index merge 발생 확인
+-- type=index_merge, Extra=Using intersect(idx_category, idx_region); Using filesort
+EXPLAIN SELECT id, title, price, thumbnail_path, category, region, reg_dt
+FROM products
+WHERE category = 'SPORTS'
+  AND region = 'GANGNAM'
+  AND status = 'ENABLE'
+  AND delete_dt IS NULL
+ORDER BY reg_dt DESC
+LIMIT 10;
+
+-- 인덱스 크기 확인
+SELECT
+    index_name,
+    ROUND(stat_value * @@innodb_page_size / 1024 / 1024, 2) AS size_mb
+FROM mysql.innodb_index_stats
+WHERE database_name = DATABASE()
+  AND table_name = 'products'
+  AND stat_name = 'size'
+ORDER BY index_name;
+
+-- 단일 인덱스 제거
+DROP INDEX idx_category ON products;
+DROP INDEX idx_region   ON products;
+
+-- ============================================================
+-- ■ STEP 2: 복합 인덱스 추가 → filesort 제거 확인
+-- ============================================================
+-- category 먼저: 선택도 20%(5개) > region 선택도 4%(25개) 이므로
+-- region이 선택도 더 높아서 앞에 와야 하지 않나? 라는 질문 대비:
+-- → WHERE 절에서 동치(=) 조건은 둘 다 같은 레벨, 이후 ORDER BY reg_dt가 핵심
+-- → region을 앞에 두면: (region, category, status, delete_dt, reg_dt) 도 가능
+-- → 실제 EXPLAIN rows 비교로 결론 도출
+
+CREATE INDEX idx_category_region ON products (category, region, status, delete_dt, reg_dt);
+
+-- type=ref, rows 대폭 감소, Extra에서 Using filesort 사라짐 확인
+EXPLAIN SELECT id, title, price, thumbnail_path, category, region, reg_dt
+FROM products
+WHERE category = 'SPORTS'
+  AND region = 'GANGNAM'
+  AND status = 'ENABLE'
+  AND delete_dt IS NULL
+ORDER BY reg_dt DESC
+LIMIT 10;
+
+-- 인덱스 크기 비교
+SELECT
+    index_name,
+    ROUND(stat_value * @@innodb_page_size / 1024 / 1024, 2) AS size_mb
+FROM mysql.innodb_index_stats
+WHERE database_name = DATABASE()
+  AND table_name = 'products'
+  AND stat_name = 'size'
+ORDER BY index_name;
+
+-- ============================================================
+-- ■ STEP 3: 커버링 인덱스 → heap lookup 제거
+-- ============================================================
+DROP INDEX idx_category_region ON products;
+
+-- SELECT 컬럼(id, title, price, thumbnail_path)까지 인덱스에 포함
+CREATE INDEX idx_covering ON products (category, region, status, delete_dt, reg_dt, id, title, price, thumbnail_path);
+
+-- Extra=Using index 확인 (heap lookup 없음)
+EXPLAIN SELECT id, title, price, thumbnail_path, category, region, reg_dt
+FROM products
+WHERE category = 'SPORTS'
+  AND region = 'GANGNAM'
+  AND status = 'ENABLE'
+  AND delete_dt IS NULL
+ORDER BY reg_dt DESC
+LIMIT 10;
+
+-- 인덱스 크기 비교 (복합 인덱스보다 커진 것 확인 → 트레이드오프)
+SELECT
+    index_name,
+    ROUND(stat_value * @@innodb_page_size / 1024 / 1024, 2) AS size_mb
+FROM mysql.innodb_index_stats
+WHERE database_name = DATABASE()
+  AND table_name = 'products'
+  AND stat_name = 'size'
+ORDER BY index_name;
+
+-- ============================================================
+-- ■ STEP 4: 쓰기 성능 트레이드오프 측정
+-- ============================================================
+-- 인덱스 없을 때 INSERT 100건 시간 측정
+SET @start = NOW(6);
+INSERT INTO products (id, seller_id, title, max_capacity, description, description_path,
+                      price, status, road_address, zonecode, latitude, longitude, category, region, reg_dt, modify_dt)
+SELECT UUID_TO_BIN(UUID(), 1), UUID_TO_BIN(UUID(), 1),
+       CONCAT('WRITE_TEST_', seq), 10, '설명', '[]',
+       50000, 'ENABLE', '서울특별시', '00000', 37.5, 126.9,
+       ELT((seq MOD 5) + 1, 'SPORTS', 'COOKING', 'ART', 'BEAUTY', 'OTHER'),
+       ELT((seq MOD 25) + 1, 'GANGNAM', 'GANGDONG', 'GANGBUK', 'GANGSEO', 'GWANAK',
+           'GWANGJIN', 'GURO', 'GEUMCHEON', 'NOWON', 'DOBONG',
+           'DONGDAEMUN', 'DONGJAK', 'MAPO', 'SEODAEMUN', 'SEOCHO',
+           'SEONGDONG', 'SEONGBUK', 'SONGPA', 'YANGCHEON', 'YEONGDEUNGPO',
+           'YONGSAN', 'EUNPYEONG', 'JONGNO', 'JUNG', 'JUNGNANG'),
+       NOW(), NOW()
+FROM (SELECT seq FROM (
+    SELECT 0 AS seq UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4
+    UNION SELECT 5 UNION SELECT 6 UNION SELECT 7 UNION SELECT 8 UNION SELECT 9
+) t1, (
+    SELECT 0 AS mul UNION SELECT 10 UNION SELECT 20 UNION SELECT 30 UNION SELECT 40
+    UNION SELECT 50 UNION SELECT 60 UNION SELECT 70 UNION SELECT 80 UNION SELECT 90
+) t2 WHERE t1.seq + t2.mul < 100) AS seqs;
+SELECT TIMESTAMPDIFF(MICROSECOND, @start, NOW(6)) / 1000 AS insert_100_ms;
+
+-- 테이블 + 인덱스 전체 크기
+SELECT
+    table_name,
+    ROUND(data_length / 1024 / 1024, 2)  AS data_mb,
+    ROUND(index_length / 1024 / 1024, 2) AS index_mb
+FROM information_schema.TABLES
+WHERE table_schema = DATABASE()
+  AND table_name = 'products';

--- a/service/product/src/main/resources/seed_products.sql
+++ b/service/product/src/main/resources/seed_products.sql
@@ -1,0 +1,94 @@
+-- ============================================================
+-- 상품 테스트 데이터 시드 스크립트
+-- category 5개 × region 25개 = 125 조합 × 40,000건 = 500만건
+-- UUID: UUID_TO_BIN(UUID(), 1) → 시간 정렬 (UUID v7 효과)
+-- ============================================================
+
+SET NAMES utf8mb4;
+
+DROP PROCEDURE IF EXISTS seed_products;
+
+DELIMITER //
+
+CREATE PROCEDURE seed_products()
+BEGIN
+    DECLARE i       INT DEFAULT 0;
+    DECLARE total   INT DEFAULT 5000000;
+    DECLARE cat_idx INT;
+    DECLARE reg_idx INT;
+
+    SET autocommit = 0;
+    SET unique_checks = 0;
+    SET foreign_key_checks = 0;
+
+    WHILE i < total DO
+        -- 125 조합 균일 분포
+        -- category: (i DIV 25) MOD 5 → 40,000건마다 변경
+        -- region:   i MOD 25         → 25건마다 순환
+        SET cat_idx = ((i DIV 25) MOD 5) + 1;
+        SET reg_idx = (i MOD 25) + 1;
+
+        INSERT INTO products (
+            id, seller_id,
+            title, max_capacity, description, description_path,
+            price, status,
+            road_address, detail_address, zonecode,
+            latitude, longitude,
+            category, region,
+            reg_dt, modify_dt, delete_dt
+        ) VALUES (
+            UUID_TO_BIN(UUID(), 1),
+            UUID_TO_BIN(UUID(), 1),
+
+            CONCAT(ELT(cat_idx, 'SPORTS', 'COOKING', 'ART', 'BEAUTY', 'OTHER'), '_클래스_', i),
+            10,
+            '클래스 설명입니다.',
+            '[]',
+
+            FLOOR(10000 + RAND() * 190000),
+            'ENABLE',
+
+            '서울특별시',
+            NULL,
+            '00000',
+            37.5665 + (RAND() - 0.5) * 0.1,
+            126.9780 + (RAND() - 0.5) * 0.1,
+
+            ELT(cat_idx, 'SPORTS', 'COOKING', 'ART', 'BEAUTY', 'OTHER'),
+
+            ELT(reg_idx,
+                'GANGNAM',    'GANGDONG',  'GANGBUK',     'GANGSEO',     'GWANAK',
+                'GWANGJIN',   'GURO',      'GEUMCHEON',   'NOWON',       'DOBONG',
+                'DONGDAEMUN', 'DONGJAK',   'MAPO',        'SEODAEMUN',   'SEOCHO',
+                'SEONGDONG',  'SEONGBUK',  'SONGPA',      'YANGCHEON',   'YEONGDEUNGPO',
+                'YONGSAN',    'EUNPYEONG', 'JONGNO',      'JUNG',        'JUNGNANG'
+            ),
+
+            NOW() - INTERVAL FLOOR(RAND() * 365) DAY,
+            NOW(),
+            NULL
+        );
+
+        SET i = i + 1;
+
+        IF i MOD 10000 = 0 THEN
+            COMMIT;
+        END IF;
+    END WHILE;
+
+    COMMIT;
+    SET autocommit = 1;
+    SET unique_checks = 1;
+    SET foreign_key_checks = 1;
+END //
+
+DELIMITER ;
+
+CALL seed_products();
+DROP PROCEDURE IF EXISTS seed_products;
+
+-- 조합별 건수 확인 (각 40,000건인지 검증)
+SELECT category, region, COUNT(*) AS cnt
+FROM products
+GROUP BY category, region
+ORDER BY category, region;


### PR DESCRIPTION
 ## 관련 이슈
  - Close #8 

  ## 변경 요약
  - Product 엔티티에 category(CategoryType), region(RegionType) 필드 추가
  - `GET /products/filter` 카테고리·지역 복합 필터 API 추가
  - 복합 인덱스 단계별 성능 분석 SQL 및 k6 부하 테스트
  스크립트 추가

  ## 주요 변경점
  - **도메인 모델**: `CategoryType`(5종), `RegionType`(서울 25개 구) enum 정의 및 Product 엔티티 컬럼 추가

  - **필터 쿼리**: `(category, region, status, delete_dt,
  reg_dt)` 복합 인덱스 기준으로 JPQL 작성
    `status=ENABLE`, `deleteDt IS NULL`, `reg_dt DESC` 조건
  포함

  - **필터 API**: `GET /products/filter?category=SPORTS&regi
  on=GANGNAM&page=0&size=10`
    Create/Update DTO에도 category, region 필드 추가

  ## 테스트
  - [x] 로컬 실행 확인
  - [x] 테스트 통과
