### PR TITLE
refactor: Redis 카운터를 활용한 좋아요/조회수 성능 개선

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,8 @@ services:
       KAFKA_HOST: kafka
       ES_URIS: http://elasticsearch:9200
       USER_SERVICE_URL: http://user-service:9003
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
       MANAGEMENT_TRACING_SAMPLING_PROBABILITY: "1.0"
       MANAGEMENT_ZIPKIN_TRACING_ENDPOINT: http://tempo:9411/api/v2/spans
     depends_on:

--- a/docs/product/product.md
+++ b/docs/product/product.md
@@ -92,7 +92,7 @@ API Gateway
 | `Schedule` | 상품별 날짜/시간 정보 | `productId`, `scheduleDt`, `startTime`, `endTime`, `status`, `capacity` |
 | `ProductUser` | 특정 일정에 대한 예약 사용자 | `productScheduleId`, `userId`, `guestCount`, `status`, `restoreStatus` |
 | `Review` | 상품 리뷰 | `productId`, `userId`, `rating`, `content` |
-| `Favorite` | 일정 찜 | `productScheduleId`, `userId`, `quantity` |
+| `Favorite` | 상품 찜 | `productId`, `userId` |
 
 ### 상태값
 
@@ -166,10 +166,13 @@ infrastructure/elasticsearch/
 | 상품 생성 | 이미지 확인, 상품 저장, 판매자 조회, ES 저장 이벤트 발행 |
 | 상품 수정 | 소유권 검증, 필드 수정, 이미지 재확인, ES 저장 이벤트 발행 |
 | 상품 삭제 | soft delete 처리, ES 삭제 이벤트 발행 |
-| 상품 검색 | ES 조회 기반 목록 반환 |
-| 상품 단건 조회 | 상품 조회 후 판매자 이름 조합 |
+| 상품 목록 조회 | MySQL 최신순 조회 + Redis multiGet으로 카운터 배치 조합 |
+| 상품 단건 조회 | DB(정적 정보) + Redis(좋아요 수, 조회수) 조합 반환, 조회수 INCR |
+| 카테고리/지역 필터 조회 | MySQL 필터 조회 + Redis multiGet 카운터 조합 |
 | 정산용 조회 | product id 목록으로 상품 정보 반환 |
 | ES 마이그레이션 | DB 데이터를 ES로 재색인 |
+
+> 상품 조회 응답은 정적 데이터(DB)와 동적 카운터(Redis)를 애플리케이션에서 조합해서 반환한다. 자세한 내용은 [redis-counter.md](redis-counter.md) 참고.
 
 ### ScheduleService
 
@@ -207,9 +210,12 @@ infrastructure/elasticsearch/
 
 | 기능 | 설명 |
 |------|------|
-| 찜 생성 | 찜 엔티티 저장 |
-| 찜 삭제 | 본인 찜 검증 후 soft delete |
-| 사용자별 찜 조회 | 활성 찜 목록 반환 |
+| 찜 생성 | 상품 존재 확인, 중복 찜 방지, DB 저장, Redis like_count INCR |
+| 찜 삭제 | 본인 찜 검증 후 soft delete, Redis like_count DECR |
+| 사용자별 찜 조회 | 활성 찜 목록 반환 (상품 단위) |
+| 좋아요 수 조회 | Redis 우선 조회, miss 시 DB COUNT(*) + SETNX 캐싱 |
+
+> 찜은 기존 스케줄 단위에서 **상품 단위**로 변경되었다. 마이페이지에서 찜한 상품 목록 확인 후 결제 시 스케줄을 다시 선택하는 흐름이다.
 
 ---
 
@@ -391,8 +397,17 @@ FavoritesRestController
 
 ### 부가 기능
 - [x] 리뷰 생성/수정/삭제/조회 구현
-- [x] 찜 생성/삭제/조회 구현
+- [x] 찜 생성/삭제/조회 구현 (상품 단위로 변경)
 - [x] 상품 검색의 ES 연동 구현
+
+### Redis 카운터
+- [x] product 서비스 Redis 설정 추가
+- [x] 좋아요 수 Redis 카운터 (INCR/DECR + miss 시 DB fallback)
+- [x] 조회수 Redis 카운터 (INCR + SETNX 초기화)
+- [x] 상품 목록 조회 시 Redis multiGet 배치 조회
+- [x] 상품 응답에 likeCount, viewCount 포함
+- [x] 좋아요 수 보정 스케줄러 (매일 새벽 3시 DB 기준 재동기화)
+- [x] 조회수 DB 동기화 스케줄러 (매시 정각 Redis → DB)
 
 ### 운영 정비 포인트
 - [ ] `products_users.status` 제약조건을 현재 enum 기준으로 정리

--- a/docs/product/redis-counter.md
+++ b/docs/product/redis-counter.md
@@ -1,0 +1,300 @@
+# Redis 카운터를 활용한 좋아요/조회수 성능 개선
+
+## 배경
+
+상품 조회수와 좋아요 수는 성격이 다른 두 가지 카운터다.
+
+| 항목 | 좋아요 수 | 조회수 |
+|------|----------|--------|
+| 성격 | 명시적 사용자 상태 | 통계성 데이터 |
+| 정합성 요구 | 높음 ("내가 눌렀는가?") | 낮음 (약간의 오차 허용) |
+| 쓰기 빈도 | 낮음 | 매우 높음 (조회마다 발생) |
+| DB 반영 전략 | 즉시 반영 | 주기적 배치 반영 (Write-Behind) |
+
+두 카운터를 같은 방식으로 처리하면 문제가 생긴다.
+- 조회수를 DB에 매번 UPDATE하면 트래픽 증가 시 Row-level lock 경합 발생
+- 좋아요를 비동기로만 처리하면 "내가 눌렀는가?" 조회의 정확성이 떨어짐
+
+따라서 데이터 특성에 맞게 전략을 분리했다.
+
+---
+
+## 핵심 설계 원칙
+
+```
+상품 정적 정보 (제목, 가격, 설명 등) → DB에서 조회
+상품 동적 카운터 (좋아요 수, 조회수) → Redis에서 조회
+→ 애플리케이션(Spring Boot)에서 DTO로 조합해서 반환
+```
+
+DB의 `view_count`는 Write-Behind 전략상 최대 1시간 전 데이터다.
+DB에서 조회수를 그대로 반환하면 사용자는 멈춰있는 숫자를 보게 된다.
+최신 카운터는 반드시 Redis에서 읽어야 한다.
+
+---
+
+## Redis 키 설계
+
+```
+like_count:product:{productId}   → 상품 좋아요 수
+view_count:product:{productId}   → 상품 조회수
+```
+
+---
+
+## 1. 좋아요 전략
+
+### 쓰기
+
+```
+좋아요 등록
+→ DB products_likes 테이블에 (userId, productId) 즉시 저장
+→ Redis like_count INCR
+→ 응답
+
+좋아요 취소
+→ DB soft delete
+→ Redis like_count DECR
+→ 응답
+```
+
+좋아요 상태(내가 눌렀는가?)는 DB가 원본이므로 DB에 동기적으로 저장한다.
+Redis INCR/DECR 실패 시 조용히 무시하고, 보정 스케줄러가 수렴시킨다.
+
+**Partial failure 처리:**
+DB 저장 성공 + Redis INCR 실패가 발생할 수 있다.
+트랜잭션으로 묶을 수 없으므로 이 오차는 허용하고, 매일 새벽 보정 스케줄러가 DB 기준으로 재동기화한다.
+
+### 읽기
+
+```
+좋아요 수 조회
+→ Redis like_count 조회
+→ 있으면 Redis 값 반환
+→ 없으면 DB COUNT(*) 조회 → SETNX로 캐싱 → 반환
+```
+
+Redis miss 시 `SETNX`(SET if Not Exists)를 사용해 동시 요청이 몰릴 때 초기화 race condition을 방지한다.
+
+### 보정 스케줄러
+
+```
+매일 새벽 3시
+→ 전체 상품 DB COUNT(*) 조회
+→ Redis like_count 재동기화
+```
+
+---
+
+## 2. 조회수 전략
+
+### 쓰기
+
+```
+상품 상세 조회 시
+→ Redis view_count 키 존재 확인
+→ 없으면: DB view_count 값으로 SETNX 초기화
+→ Redis INCR
+→ 응답
+```
+
+SETNX 초기화 예시:
+```
+DB view_count = 100, Redis 키 없음
+
+첫 번째 조회 요청
+→ SETNX view_count:product:{id} "100"  (한 번만 성공)
+→ INCR
+→ Redis = 101
+```
+
+DB에는 주기적으로 반영한다.
+```
+매시 정각
+→ Redis view_count → DB view_count UPDATE
+→ Redis 키가 없는 상품은 skip
+```
+
+### 읽기
+
+```
+상세 조회
+→ Redis view_count 있으면 Redis 값 반환
+→ 없으면 DB view_count 값으로 SETNX 초기화 후 INCR → 반환
+
+목록 조회 (write-through)
+→ Redis multiGet으로 배치 조회
+→ miss 항목은 Product 엔티티의 view_count로 SETNX 캐싱 → 반환
+→ 이후 조회부터 Redis hit
+```
+
+목록 조회 시 miss가 발생해도 이미 로드된 Product 엔티티에 view_count가 있으므로 추가 DB 쿼리 없이 Redis에 등록된다.
+
+### Redis 장애 처리
+
+Redis 장애 시 조회수 INCR 실패는 조용히 무시한다.
+조회 자체를 막지 않으며, DB의 `view_count` 값을 fallback으로 반환한다.
+
+```java
+try {
+    redisTemplate.opsForValue().increment(key);
+} catch (Exception e) {
+    log.warn("Redis view_count INCR 실패: {}", e.getMessage());
+    // 조회 응답은 정상적으로 반환
+}
+```
+
+---
+
+## 3. 목록 조회 최적화 (multiGet)
+
+상품 목록 조회 시 N개 상품의 카운터를 개별 조회하면 Redis 요청이 N번 발생한다.
+`multiGet`으로 한 번에 배치 조회한다.
+
+```
+상품 목록 10개 조회
+→ productId 10개 추출
+→ Redis multiGet(["like_count:product:id1", ..., "like_count:product:id10"]) → 1번
+→ Redis multiGet(["view_count:product:id1", ..., "view_count:product:id10"]) → 1번
+→ DB 결과 + Redis 결과 조합
+→ 응답
+```
+
+**좋아요 miss:** DB에서 IN + GROUP BY 배치 조회로 보완한다.
+**조회수 miss:** 이미 로드된 Product 엔티티의 `view_count` 값을 `SETNX`로 Redis에 캐싱 후 반환한다. 추가 DB 쿼리 없음.
+`searchMy`(ES 기반)는 ProductDocument에 view_count가 없으므로 write-through 미적용, 0을 반환한다.
+
+---
+
+## 4. 트레이드오프 정리
+
+| 항목 | 선택 | 이유 |
+|------|------|------|
+| 좋아요 DB 즉시 반영 | 유지 | 상태 정확성이 핵심 |
+| 조회수 Write-Behind | 선택 | 매번 UPDATE 시 DB 부하 |
+| 조회수 목록 miss 시 write-through | 선택 | Product 엔티티 재활용, 추가 쿼리 없음 |
+| Partial failure 허용 (좋아요) | 허용 | 보정 스케줄러로 수렴 |
+| 조회수 최대 1시간 손실 허용 | 허용 | 통계성 데이터이므로 허용 범위 |
+| Redis 장애 시 fallback | DB 값 반환 | 서비스 가용성 우선 |
+
+---
+
+## 5. 성능 비교 테스트
+
+### 테스트 목적
+
+Redis 카운터 전략의 실제 효과를 수치로 검증한다.
+
+좋아요/조회수 Redis 캐싱의 이점을 두 가지로 나눠서 생각했다.
+
+| 관점 | 내용 | 검증 가능 여부 |
+|------|------|--------------|
+| 쓰기 경합 감소 | 핫 상품 동시 UPDATE → row lock 경합 → Redis INCR으로 제거 | ✅ 수치로 명확히 드러남 |
+| 읽기 부하 감소 | DB COUNT(*) → Redis GET으로 대체 | ⚠️ 현재 데이터 규모에서 차이 미미 |
+
+읽기 관점에서는 어차피 상품 정보 조회를 위해 DB에 접근하므로 카운터 읽기 최적화 효과가 전체 응답시간에서 차지하는 비율이 작다. 또한 favorites 테이블 데이터가 적으면 DB COUNT 자체도 빠르기 때문에 현재 규모에서 극적인 차이를 내기 어렵다.
+
+따라서 **쓰기 경합 제거** 를 핵심 검증 포인트로 삼았다.
+
+---
+
+### 비교 시나리오
+
+**Before**: 상세 조회 시 DB에 직접 UPDATE
+```sql
+UPDATE products SET view_count = view_count + 1 WHERE id = ?
+```
+
+**After**: 상세 조회 시 Redis INCR
+```
+INCR view_count:product:{id}
+```
+
+---
+
+### 테스트 설계
+
+핫 상품 1개에 트래픽을 집중시켜 row lock 경합을 극대화했다.
+
+```
+VU: 100
+sleep: 없음 (최대한 빠르게 요청)
+대상: 동일한 상품 1개에 모든 트래픽 집중
+→ 100 VU가 같은 row를 동시에 UPDATE → InnoDB row lock 경합 극대화
+```
+
+sleep을 제거하고 단일 상품에 집중한 이유:
+- sleep이 있으면 VU당 요청 주기가 길어져 동시 경합이 거의 발생하지 않음
+- 여러 상품에 분산하면 경합이 희석되어 차이가 드러나지 않음
+
+---
+
+### 비교 엔드포인트
+
+| | 엔드포인트 | view_count 처리 |
+|--|-----------|----------------|
+| Before | `GET /api/v1/products/{id}/no-cache` | DB UPDATE (매 요청마다) |
+| After | `GET /api/v1/products/{id}` | Redis INCR |
+
+`/no-cache` 엔드포인트는 성능 비교 목적으로만 존재한다.
+
+---
+
+### k6 스크립트
+
+```
+k6/detail-no-cache.js   → Before 측정
+k6/detail-with-redis.js → After 측정
+```
+
+---
+
+### 읽기 비교를 별도로 측정하지 않은 이유
+
+읽기 관점(DB COUNT vs Redis GET)의 차이는 다음 조건에서만 드러난다.
+
+- favorites 테이블이 수십만 건 이상 쌓여 DB COUNT가 느려질 때
+- 또는 product_id 인덱스가 없어 Full Table Scan이 발생할 때
+
+현재 테스트 환경에서는 인덱스가 있고 데이터가 적어 DB COUNT 자체가 빠르게 동작한다. 읽기 비교보다 쓰기 경합 시나리오에서 차이가 명확하게 드러난다.
+
+---
+
+## 6. 구현 파일 위치
+
+| 역할 | 파일 |
+|------|------|
+| 좋아요 등록/취소 + Redis INCR/DECR | `FavoriteService.java` |
+| 좋아요 수 조회 (Redis 우선) | `FavoriteService.getLikeCount()` |
+| 조회수 INCR + 상품 응답 조합 | `ProductService.incrementAndGetViewCount()` |
+| 목록 카운터 배치 조회 | `ProductService.batchGetCounts()` |
+| 조회수 목록 miss write-through | `ProductService.writeViewCountCache()` |
+| Redis 설정 | `config/RedisConfig.java` |
+| 좋아요 수 보정 스케줄러 | `scheduled/LikeCountSyncScheduler.java` |
+| 조회수 DB 동기화 스케줄러 | `scheduled/ViewCountSyncScheduler.java` |
+
+---
+
+## 6. 스케줄러 상세
+
+### LikeCountSyncScheduler
+
+```
+매일 새벽 3시 (cron: 0 0 3 * * *)
+→ DB: SELECT product_id, COUNT(*) FROM products_likes WHERE delete_dt IS NULL GROUP BY product_id
+→ Redis: SET like_count:product:{id} {count}
+```
+
+DB COUNT(*) 결과를 기준으로 Redis 값을 덮어씌워 Partial failure로 누적된 오차를 수렴시킨다.
+
+### ViewCountSyncScheduler
+
+```
+매시 정각 (cron: 0 0 * * * *)
+→ Redis SCAN view_count:product:* (커서 기반, 100개 단위)
+→ 각 키에서 productId 추출, value 읽기
+→ DB: UPDATE products SET view_count = {value} WHERE id = {productId}
+```
+
+`KEYS *` 대신 `SCAN`을 사용해 Redis를 블로킹하지 않는다.
+Redis에 키가 없는 상품(조회된 적 없는 상품)은 자동으로 skip된다.

--- a/k6/detail-no-cache.js
+++ b/k6/detail-no-cache.js
@@ -1,0 +1,43 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+/**
+ * [Before] 상세 조회 시 DB UPDATE view_count - 핫 상품 집중 부하 테스트
+ * k6 run k6/detail-no-cache.js
+ *
+ * 핫 상품 10개에 트래픽 집중 → 동일 row UPDATE 경합 극대화
+ */
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:9004';
+
+const HOT_IDS = [
+  '7d6a65b4-54c4-11f1-970e-32853ff0268d',
+  '7d6b1109-54c4-11f1-970e-32853ff0268d',
+  '7d6a7a91-54c4-11f1-970e-32853ff0268d',
+  '7d6b2407-54c4-11f1-970e-32853ff0268d',
+  '7d6a8f74-54c4-11f1-970e-32853ff0268d',
+  '7d6ae94e-54c4-11f1-970e-32853ff0268d',
+  '7d6b3a01-54c4-11f1-970e-32853ff0268d',
+  '7d6aa554-54c4-11f1-970e-32853ff0268d',
+  '7d6afd83-54c4-11f1-970e-32853ff0268d',
+  '7d6acbd9-54c4-11f1-970e-32853ff0268d',
+];
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 10  },
+    { duration: '40s', target: 100 },
+    { duration: '10s', target: 0   },
+  ],
+  thresholds: {
+    http_req_failed:   ['rate<0.05'],
+    http_req_duration: ['p(95)<3000'],
+  },
+};
+
+export default function () {
+  const id = HOT_IDS[0];
+
+  const res = http.get(`${BASE_URL}/api/v1/products/${id}/no-cache`);
+  check(res, { '200 OK': (r) => r.status === 200 });
+}

--- a/k6/detail-with-redis.js
+++ b/k6/detail-with-redis.js
@@ -1,0 +1,43 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+/**
+ * [After] 상세 조회 시 Redis INCR view_count - 핫 상품 집중 부하 테스트
+ * k6 run k6/detail-with-redis.js
+ *
+ * 핫 상품 10개에 트래픽 집중 → Redis INCR 원자 연산으로 경합 없음
+ */
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:9004';
+
+const HOT_IDS = [
+  '7d6a65b4-54c4-11f1-970e-32853ff0268d',
+  '7d6b1109-54c4-11f1-970e-32853ff0268d',
+  '7d6a7a91-54c4-11f1-970e-32853ff0268d',
+  '7d6b2407-54c4-11f1-970e-32853ff0268d',
+  '7d6a8f74-54c4-11f1-970e-32853ff0268d',
+  '7d6ae94e-54c4-11f1-970e-32853ff0268d',
+  '7d6b3a01-54c4-11f1-970e-32853ff0268d',
+  '7d6aa554-54c4-11f1-970e-32853ff0268d',
+  '7d6afd83-54c4-11f1-970e-32853ff0268d',
+  '7d6acbd9-54c4-11f1-970e-32853ff0268d',
+];
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 10  },
+    { duration: '40s', target: 100 },
+    { duration: '10s', target: 0   },
+  ],
+  thresholds: {
+    http_req_failed:   ['rate<0.05'],
+    http_req_duration: ['p(95)<3000'],
+  },
+};
+
+export default function () {
+  const id = HOT_IDS[0];
+
+  const res = http.get(`${BASE_URL}/api/v1/products/${id}`);
+  check(res, { '200 OK': (r) => r.status === 200 });
+}

--- a/k6/no-cache.js
+++ b/k6/no-cache.js
@@ -1,0 +1,30 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+/**
+ * [Before] Redis 없이 DB 직접 조회 - TPS 측정
+ * k6 run k6/no-cache.js
+ */
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:9004';
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 10  },
+    { duration: '40s', target: 100 },
+    { duration: '10s', target: 0   },
+  ],
+  thresholds: {
+    http_req_failed:   ['rate<0.05'],
+    http_req_duration: ['p(95)<3000'],
+  },
+};
+
+export default function () {
+  const page = Math.floor(Math.random() * 100);
+
+  const res = http.get(`${BASE_URL}/api/v1/products/no-cache?thisPage=${page}&pageSize=10`);
+  check(res, { '200 OK': (r) => r.status === 200 });
+
+  sleep(0.1);
+}

--- a/k6/redis-counter-comparison.js
+++ b/k6/redis-counter-comparison.js
@@ -1,0 +1,94 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+/**
+ * Redis 카운터 전략 Before/After TPS 비교 테스트
+ *
+ * [사용법]
+ *
+ * Step 1 — Redis 실행 상태 측정 (After)
+ *   k6 run -e SCENARIO=with_redis k6/redis-counter-comparison.js
+ *
+ * Step 2 — Redis 중단 후 측정 (Before)
+ *   docker stop <redis-container>
+ *   k6 run -e SCENARIO=no_redis k6/redis-counter-comparison.js
+ *   docker start <redis-container>
+ *
+ * [측정 근거]
+ *   - 상품 10,000건 (일반 9,990 + 핫 10)
+ *   - VU 100 : MAU 1만 명 기준 피크 시간대 동시 접속 1%
+ *   - 파레토 법칙 : 핫 상품 10개에 트래픽 80% 집중
+ *     → Redis 없을 때 동일 row UPDATE 경합이 극대화되어 before/after 차이가 명확히 드러남
+ *   - 요청 비율 : 목록 70% / 상세 30%
+ *     → 실제 서비스 패턴 반영 (목록 → 상세 유입 흐름)
+ */
+
+const BASE_URL  = __ENV.BASE_URL  || 'http://localhost:9004';
+const SCENARIO  = __ENV.SCENARIO  || 'with_redis';
+
+// 핫 상품 10개 (seed-products.sql 실행 결과)
+const HOT_IDS = [
+  '7d6a65b4-54c4-11f1-970e-32853ff0268d',
+  '7d6b1109-54c4-11f1-970e-32853ff0268d',
+  '7d6a7a91-54c4-11f1-970e-32853ff0268d',
+  '7d6b2407-54c4-11f1-970e-32853ff0268d',
+  '7d6a8f74-54c4-11f1-970e-32853ff0268d',
+  '7d6ae94e-54c4-11f1-970e-32853ff0268d',
+  '7d6b3a01-54c4-11f1-970e-32853ff0268d',
+  '7d6aa554-54c4-11f1-970e-32853ff0268d',
+  '7d6afd83-54c4-11f1-970e-32853ff0268d',
+  '7d6acbd9-54c4-11f1-970e-32853ff0268d',
+];
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 10  },  // warm-up
+    { duration: '40s', target: 100 },  // ramp-up
+    { duration: '10s', target: 0   },  // cool-down
+  ],
+  thresholds: {
+    http_req_failed:   ['rate<0.05'],
+    http_req_duration: ['p(95)<3000'],
+  },
+};
+
+// setup: 일반 상품 ID를 API에서 동적으로 수집 (랜덤 분산용)
+export function setup() {
+  const ids = [];
+  for (let page = 0; page < 5; page++) {
+    const res = http.get(`${BASE_URL}/api/v1/products?thisPage=${page}&pageSize=10`);
+    if (res.status !== 200) continue;
+    const body = JSON.parse(res.body);
+    const content = body.data?.content || [];
+    content.forEach(p => {
+      if (!HOT_IDS.includes(p.id)) ids.push(p.id);
+    });
+  }
+  return { normalIds: ids };
+}
+
+export default function (data) {
+  const page = Math.floor(Math.random() * 100);
+
+  // ── with_redis: Redis 캐시 사용 ───────────────────────────────────────────
+  const withRedisRes = http.get(
+    `${BASE_URL}/api/v1/products?thisPage=${page}&pageSize=10`,
+    { tags: { type: 'with_redis' } }
+  );
+  check(withRedisRes, {
+    'with_redis 200': (r) => r.status === 200,
+    'with_redis p95 < 500ms': (r) => r.timings.duration < 500,
+  });
+
+  // ── no_cache: DB 직접 조회 ────────────────────────────────────────────────
+  const noCacheRes = http.get(
+    `${BASE_URL}/api/v1/products/no-cache?thisPage=${page}&pageSize=10`,
+    { tags: { type: 'no_cache' } }
+  );
+  check(noCacheRes, {
+    'no_cache 200': (r) => r.status === 200,
+    'no_cache p95 < 500ms': (r) => r.timings.duration < 500,
+  });
+
+  sleep(0.1);
+}

--- a/k6/with-redis.js
+++ b/k6/with-redis.js
@@ -1,0 +1,30 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+
+/**
+ * [After] Redis 캐시 사용 - TPS 측정
+ * k6 run k6/with-redis.js
+ */
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:9004';
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 10  },
+    { duration: '40s', target: 100 },
+    { duration: '10s', target: 0   },
+  ],
+  thresholds: {
+    http_req_failed:   ['rate<0.05'],
+    http_req_duration: ['p(95)<3000'],
+  },
+};
+
+export default function () {
+  const page = Math.floor(Math.random() * 100);
+
+  const res = http.get(`${BASE_URL}/api/v1/products?thisPage=${page}&pageSize=10`);
+  check(res, { '200 OK': (r) => r.status === 200 });
+
+  sleep(0.1);
+}

--- a/service/product/build.gradle
+++ b/service/product/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     implementation 'software.amazon.awssdk:s3-transfer-manager'
 
     implementation 'com.github.f4b6a3:uuid-creator:6.0.0'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/service/product/src/main/java/jabaclass/product/application/scheduled/LikeCountSyncScheduler.java
+++ b/service/product/src/main/java/jabaclass/product/application/scheduled/LikeCountSyncScheduler.java
@@ -1,0 +1,53 @@
+package jabaclass.product.application.scheduled;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import jabaclass.product.domain.repository.FavoriteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LikeCountSyncScheduler {
+
+	private static final String LIKE_COUNT_KEY = "like_count:product:";
+
+	private final FavoriteRepository favoriteRepository;
+	private final StringRedisTemplate redisTemplate;
+
+	@Scheduled(cron = "0 0 3 * * *")
+	public void syncLikeCount() {
+		log.info("좋아요 수 보정 시작");
+
+		Map<UUID, Long> countMap = favoriteRepository.countAllGroupByProductId();
+
+		countMap.forEach((productId, count) ->
+			redisTemplate.opsForValue().set(LIKE_COUNT_KEY + productId, String.valueOf(count))
+		);
+
+		ScanOptions options = ScanOptions.scanOptions().match(LIKE_COUNT_KEY + "*").count(100).build();
+		int resetCount = 0;
+		try (Cursor<String> cursor = redisTemplate.scan(options)) {
+			while (cursor.hasNext()) {
+				String key = cursor.next();
+				UUID productId = UUID.fromString(key.replace(LIKE_COUNT_KEY, ""));
+				if (!countMap.containsKey(productId)) {
+					redisTemplate.opsForValue().set(key, "0");
+					resetCount++;
+				}
+			}
+		} catch (Exception e) {
+			log.error("좋아요 수 0 보정 실패: {}", e.getMessage());
+		}
+
+		log.info("좋아요 수 보정 완료 - 동기화: {}개, 0 보정: {}개", countMap.size(), resetCount);
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/application/scheduled/ViewCountSyncScheduler.java
+++ b/service/product/src/main/java/jabaclass/product/application/scheduled/ViewCountSyncScheduler.java
@@ -1,0 +1,57 @@
+package jabaclass.product.application.scheduled;
+
+import java.util.UUID;
+
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import jabaclass.product.domain.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ViewCountSyncScheduler {
+
+	private static final String VIEW_COUNT_KEY_PREFIX = "view_count:product:";
+
+	private final ProductRepository productRepository;
+	private final StringRedisTemplate redisTemplate;
+
+	// 매시 정각 Redis view_count → DB 반영
+	@Scheduled(cron = "0 0 * * * *")
+	@Transactional
+	public void syncViewCount() {
+		log.info("조회수 DB 동기화 시작");
+
+		ScanOptions options = ScanOptions.scanOptions()
+			.match(VIEW_COUNT_KEY_PREFIX + "*")
+			.count(100)
+			.build();
+
+		int syncCount = 0;
+		try (Cursor<String> cursor = redisTemplate.scan(options)) {
+			while (cursor.hasNext()) {
+				String key = cursor.next();
+				String value = redisTemplate.opsForValue().get(key);
+				if (value == null) {
+					continue;
+				}
+
+				UUID productId = UUID.fromString(key.replace(VIEW_COUNT_KEY_PREFIX, ""));
+				long viewCount = Long.parseLong(value);
+				productRepository.updateViewCount(productId, viewCount);
+				syncCount++;
+			}
+		} catch (Exception e) {
+			log.error("조회수 DB 동기화 실패: {}", e.getMessage());
+		}
+
+		log.info("조회수 DB 동기화 완료 - 동기화 상품 수: {}", syncCount);
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/application/service/FavoriteService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/FavoriteService.java
@@ -1,12 +1,14 @@
 package jabaclass.product.application.service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.springframework.stereotype.Service;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jabaclass.product.application.exception.BusinessException;
@@ -14,10 +16,8 @@ import jabaclass.product.application.usecase.FavoriteUseCase;
 import jabaclass.product.common.exception.CommonErrorCode;
 import jabaclass.product.domain.model.Favorite;
 import jabaclass.product.domain.model.Product;
-import jabaclass.product.domain.model.Schedule;
 import jabaclass.product.domain.repository.FavoriteRepository;
 import jabaclass.product.domain.repository.ProductRepository;
-import jabaclass.product.domain.repository.ScheduleRepository;
 import jabaclass.product.infrastructure.event.dto.ProductWishlistedEvent;
 import jabaclass.product.presentation.dto.response.FavoritesResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -28,30 +28,38 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 @Slf4j
 public class FavoriteService implements FavoriteUseCase {
+
+	private static final String LIKE_COUNT_KEY = "like_count:product:";
+
 	private final FavoriteRepository favoriteRepository;
-	private final ScheduleRepository scheduleRepository;
 	private final ProductRepository productRepository;
 	private final ApplicationEventPublisher publisher;
+	private final StringRedisTemplate redisTemplate;
 
 	@Override
 	@Transactional
-	public FavoritesResponseDto createFavorite(int quantity, UUID scheduleId, UUID userId) {
-		log.info("찜 생성 요청 수신: userId={}, scheduleId={}, quantity={}", userId, scheduleId, quantity);
-		Schedule schedule = scheduleRepository.findByIdAndDeleteDtIsNull(scheduleId)
-			.orElseThrow(() -> new BusinessException(CommonErrorCode.SCHDULES_NOT_FOUND));
-		log.info("찜 대상 일정 조회 완료: scheduleId={}, productId={}", scheduleId, schedule.getProductId());
+	public FavoritesResponseDto createFavorite(UUID productId, UUID userId) {
+		log.info("찜 생성 요청 수신: userId={}, productId={}", userId, productId);
+
+		productRepository.findById(productId)
+			.orElseThrow(() -> new BusinessException(CommonErrorCode.PRODUCT_NOT_FOUND));
+
+		Favorite existing = favoriteRepository.findByUserIdAndProductIdAndDeleteDtIsNull(userId, productId);
+		if (existing != null) {
+			throw new BusinessException(CommonErrorCode.ALREADY_LIKED);
+		}
 
 		Favorite favorite = Favorite.builder()
-			.productScheduleId(scheduleId)
+			.productId(productId)
 			.userId(userId)
-			.quantity(quantity)
 			.build();
 
 		Favorite savedFavorite = favoriteRepository.save(favorite);
-		log.info("찜 저장 완료: favoriteId={}, userId={}, productId={}",
-			savedFavorite.getId(), userId, schedule.getProductId());
-		publisher.publishEvent(ProductWishlistedEvent.of(userId, schedule.getProductId()));
-		log.info("찜 이벤트 발행 요청 완료: userId={}, productId={}", userId, schedule.getProductId());
+		log.info("찜 저장 완료: favoriteId={}, userId={}, productId={}", savedFavorite.getId(), userId, productId);
+
+		incrementLikeCount(productId);
+
+		publisher.publishEvent(ProductWishlistedEvent.of(userId, productId));
 
 		return FavoritesResponseDto.from(savedFavorite);
 	}
@@ -59,8 +67,6 @@ public class FavoriteService implements FavoriteUseCase {
 	@Override
 	@Transactional
 	public void deleteFavorite(UUID favoriteId, UUID userId) {
-
-		// 본인 상품인지 확인
 		Favorite matched = favoriteRepository.findByIdAndUserIdAndDeleteDtIsNull(favoriteId, userId);
 
 		if (matched == null) {
@@ -68,6 +74,7 @@ public class FavoriteService implements FavoriteUseCase {
 		}
 
 		matched.changeDelete();
+		decrementLikeCount(matched.getProductId());
 	}
 
 	@Override
@@ -78,44 +85,81 @@ public class FavoriteService implements FavoriteUseCase {
 			return List.of();
 		}
 
-		// 1. 찜 목록의 스케줄 ID 추출 후 일괄 조회
-		List<UUID> scheduleIds = favorites.stream()
-			.map(Favorite::getProductScheduleId)
-			.toList();
-		Map<UUID, Schedule> scheduleMap = scheduleRepository.findAllByIdInAndDeleteDtIsNull(scheduleIds)
-			.stream()
-			.collect(Collectors.toMap(Schedule::getId, s -> s));
-
-		// 2. 유효한 스케줄의 상품 ID 추출 후 일괄 조회
-		List<UUID> productIds = scheduleMap.values().stream()
-			.map(Schedule::getProductId)
+		List<UUID> productIds = favorites.stream()
+			.map(Favorite::getProductId)
 			.distinct()
 			.toList();
+
 		Map<UUID, Product> productMap = productRepository.findAllByIdsAndDeleteDtIsNull(productIds)
 			.stream()
 			.collect(Collectors.toMap(Product::getId, p -> p));
 
-		// 3. 유효한 찜 항목만 응답 생성
 		return favorites.stream()
 			.filter(f -> {
-				if (!scheduleMap.containsKey(f.getProductScheduleId())) {
-					log.warn("찜 항목의 일정을 찾을 수 없습니다. favoriteId={}, scheduleId={}",
-						f.getId(), f.getProductScheduleId());
-					return false;
-				}
-				Schedule schedule = scheduleMap.get(f.getProductScheduleId());
-				if (!productMap.containsKey(schedule.getProductId())) {
-					log.warn("찜 항목의 상품을 찾을 수 없습니다. favoriteId={}, productId={}",
-						f.getId(), schedule.getProductId());
+				if (!productMap.containsKey(f.getProductId())) {
+					log.warn("찜 항목의 상품을 찾을 수 없습니다. favoriteId={}, productId={}", f.getId(), f.getProductId());
 					return false;
 				}
 				return true;
 			})
-			.map(f -> {
-				Schedule schedule = scheduleMap.get(f.getProductScheduleId());
-				Product product = productMap.get(schedule.getProductId());
-				return FavoritesResponseDto.from(f, schedule, product);
-			})
+			.map(f -> FavoritesResponseDto.from(f, productMap.get(f.getProductId())))
 			.toList();
+	}
+
+	@Override
+	public Map<UUID, Long> getLikeCountBatch(List<UUID> productIds) {
+		Map<UUID, Long> dbCounts = new HashMap<>(favoriteRepository.countGroupByProductIdIn(productIds));
+		productIds.forEach(id -> dbCounts.putIfAbsent(id, 0L));
+		dbCounts.forEach((id, count) ->
+			redisTemplate.opsForValue().setIfAbsent(LIKE_COUNT_KEY + id, String.valueOf(count))
+		);
+		return dbCounts;
+	}
+
+	@Override
+	public Map<UUID, Long> getLikeCountBatchNoCache(List<UUID> productIds) {
+		Map<UUID, Long> dbCounts = new HashMap<>(favoriteRepository.countGroupByProductIdIn(productIds));
+		productIds.forEach(id -> dbCounts.putIfAbsent(id, 0L));
+		return dbCounts;
+	}
+
+	@Override
+	public long getLikeCount(UUID productId) {
+		String key = LIKE_COUNT_KEY + productId;
+		String cached = redisTemplate.opsForValue().get(key);
+
+		if (cached != null) {
+			return Long.parseLong(cached);
+		}
+
+		// Redis miss: DB에서 COUNT 조회 후 SETNX로 캐싱
+		long count = favoriteRepository.countByProductIdAndDeleteDtIsNull(productId);
+		redisTemplate.opsForValue().setIfAbsent(key, String.valueOf(count));
+		return count;
+	}
+
+	private void incrementLikeCount(UUID productId) {
+		try {
+			String key = LIKE_COUNT_KEY + productId;
+			// 키가 없으면 DB 기준으로 초기화 후 INCR
+			if (Boolean.FALSE.equals(redisTemplate.hasKey(key))) {
+				long count = favoriteRepository.countByProductIdAndDeleteDtIsNull(productId);
+				redisTemplate.opsForValue().setIfAbsent(key, String.valueOf(count));
+			}
+			redisTemplate.opsForValue().increment(key);
+		} catch (Exception e) {
+			log.warn("Redis like_count INCR 실패 (productId={}): {}", productId, e.getMessage());
+		}
+	}
+
+	private void decrementLikeCount(UUID productId) {
+		try {
+			String key = LIKE_COUNT_KEY + productId;
+			if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+				redisTemplate.opsForValue().decrement(key);
+			}
+		} catch (Exception e) {
+			log.warn("Redis like_count DECR 실패 (productId={}): {}", productId, e.getMessage());
+		}
 	}
 }

--- a/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
+++ b/service/product/src/main/java/jabaclass/product/application/service/ProductService.java
@@ -1,5 +1,6 @@
 package jabaclass.product.application.service;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -13,6 +14,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,31 +23,32 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jabaclass.product.application.acl.SellerRepository;
 import jabaclass.product.application.exception.BusinessException;
+import jabaclass.product.application.usecase.FavoriteUseCase;
 import jabaclass.product.application.usecase.ProductUseCase;
-import jabaclass.product.domain.model.status.CategoryType;
-import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.application.usecase.ValidateFileUseCase;
 import jabaclass.product.common.exception.CommonErrorCode;
 import jabaclass.product.domain.model.Product;
 import jabaclass.product.domain.model.ProductImageItem;
+import jabaclass.product.domain.model.status.CategoryType;
 import jabaclass.product.domain.model.status.ProductStatus;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.repository.ProductRepository;
 import jabaclass.product.domain.repository.ProductSearchRepository;
 import jabaclass.product.infrastructure.acl.dto.response.UserResponseDto;
 import jabaclass.product.infrastructure.elasticsearch.ProductDocument;
-import jabaclass.product.infrastructure.event.dto.ProductAiSyncedEvent;   // 추가
-import jabaclass.product.infrastructure.event.dto.ProductDeletedEvent;    // 추가
+import jabaclass.product.infrastructure.event.dto.ProductAiSyncedEvent;
+import jabaclass.product.infrastructure.event.dto.ProductDeletedEvent;
 import jabaclass.product.infrastructure.event.dto.ProductEventResponseDto;
 import jabaclass.product.infrastructure.event.dto.ProductViewedEvent;
 import jabaclass.product.infrastructure.kafka.ProductEsIndexMessage;
 import jabaclass.product.infrastructure.outbox.EsEventType;
 import jabaclass.product.infrastructure.outbox.OutboxEvent;
 import jabaclass.product.infrastructure.outbox.OutboxRepository;
+import jabaclass.product.application.dto.FileConfirmResponse;
 import jabaclass.product.presentation.dto.request.CreateProductRequestDto;
 import jabaclass.product.presentation.dto.request.SearchProductRequestDto;
 import jabaclass.product.presentation.dto.request.UpdateProductRequestDto;
 import jabaclass.product.presentation.dto.response.DeleteProductResponseDto;
-import jabaclass.product.application.dto.FileConfirmResponse;
 import jabaclass.product.presentation.dto.response.ProductResponseDto;
 import jabaclass.product.presentation.dto.response.ProductSettlementItemResponseDto;
 import jabaclass.product.presentation.dto.response.SearchProductResponseDto;
@@ -55,6 +58,10 @@ import jabaclass.product.presentation.dto.response.SearchProductResponseDto;
 @RequiredArgsConstructor
 @Slf4j
 public class ProductService implements ProductUseCase {
+
+	private static final String VIEW_COUNT_KEY = "view_count:product:";
+	private static final String LIKE_COUNT_KEY = "like_count:product:";
+
 	private final ProductRepository productRepository;
 	private final ProductSearchRepository productSearchRepository;
 	private final SellerRepository sellerRepository;
@@ -62,6 +69,8 @@ public class ProductService implements ProductUseCase {
 	private final ValidateFileUseCase validateFileUseCase;
 	private final OutboxRepository outboxRepository;
 	private final ObjectMapper objectMapper;
+	private final StringRedisTemplate redisTemplate;
+	private final FavoriteUseCase favoriteUseCase;
 
 	@Override
 	@Transactional
@@ -98,10 +107,11 @@ public class ProductService implements ProductUseCase {
 		UserResponseDto seller = findBySellerIdOrThrow(sellerId);
 
 		publisher.publishEvent(new ProductEventResponseDto(saved.getId()));
-		publisher.publishEvent(ProductAiSyncedEvent.from(saved));           // 추가
+		publisher.publishEvent(ProductAiSyncedEvent.from(saved));
 		saveEsSaveOutbox(saved, seller.name());
 		return ProductResponseDto.from(saved, seller.name());
 	}
+
 	@Override
 	@Transactional
 	public ProductResponseDto update(UpdateProductRequestDto requestDto, UUID productId, UUID sellerId) {
@@ -122,7 +132,6 @@ public class ProductService implements ProductUseCase {
 		product.changeCategory(requestDto.category());
 		product.changeRegion(requestDto.region());
 
-		// 이미지 수정 — null이면 기존 이미지 유지
 		if (requestDto.imageIds() != null) {
 			List<ProductImageItem> images = List.of();
 			if (!requestDto.imageIds().isEmpty()) {
@@ -136,7 +145,7 @@ public class ProductService implements ProductUseCase {
 			product.changeImages(images);
 		}
 		UserResponseDto seller = findBySellerIdOrThrow(sellerId);
-		publisher.publishEvent(ProductAiSyncedEvent.from(product));         // 추가
+		publisher.publishEvent(ProductAiSyncedEvent.from(product));
 		saveEsSaveOutbox(product, seller.name());
 		return ProductResponseDto.from(product, seller.name());
 	}
@@ -144,37 +153,61 @@ public class ProductService implements ProductUseCase {
 	@Override
 	@Transactional
 	public DeleteProductResponseDto delete(UUID productId, UUID sellerId) {
-		// 상품 존재하는지 확인
 		Product product = findByIdOrThrow(productId);
-		// 본인 상품인지 확인
 		matchProductAndSellerId(productId, sellerId);
 
 		product.changeStatus(ProductStatus.DISABLE);
 		product.changeDelete();
-		publisher.publishEvent(ProductDeletedEvent.of(productId));          // 추가
+		publisher.publishEvent(ProductDeletedEvent.of(productId));
 		saveEsDeleteOutbox(productId.toString());
 
 		return DeleteProductResponseDto.from(productId, ProductStatus.DISABLE);
 	}
 
-	// es 추가
+	// MySQL 최신순 조회 + Redis 카운터 조합
 	@Override
 	public SearchProductResponseDto searchAll(SearchProductRequestDto requestDto) {
 		Pageable pageable = PageRequest.of(requestDto.thisPage(), requestDto.pageSize());
 
-		Page<ProductDocument> page;
+		Page<Product> page;
 		if (requestDto.title() == null || requestDto.title().isBlank()) {
-			page = productSearchRepository.findAllEnabled(pageable);
+			page = productRepository.findByStatusAndDeleteDtIsNull(ProductStatus.ENABLE, pageable);
 		} else {
-			page = productSearchRepository.searchByKeyword(requestDto.title(), pageable);
+			page = productRepository.findByStatusAndTitleContainingAndDeleteDtIsNull(
+				ProductStatus.ENABLE, requestDto.title(), pageable);
 		}
 
-		// ES 문서에 sellerName이 비정규화되어 있어 user 서비스 추가 호출 불필요
+		List<UUID> productIds = page.getContent().stream().map(Product::getId).toList();
+		List<UUID> sellerIds = page.getContent().stream().map(Product::getSellerId).distinct().toList();
+
+		Map<UUID, String> sellerNameMap = sellerRepository.findSellerList(sellerIds)
+			.map(list -> list.stream().collect(Collectors.toMap(UserResponseDto::userId, UserResponseDto::name)))
+			.orElse(Map.of());
+
+		Map<UUID, Long> likeCounts = batchGetCounts(productIds, LIKE_COUNT_KEY);
+		Map<UUID, Long> viewCounts = batchGetCounts(productIds, VIEW_COUNT_KEY);
+
+		List<UUID> likeMissIds = productIds.stream().filter(id -> !likeCounts.containsKey(id)).toList();
+		if (!likeMissIds.isEmpty()) {
+			likeCounts.putAll(favoriteUseCase.getLikeCountBatch(likeMissIds));
+		}
+
+		List<Product> viewMissProducts = page.getContent().stream()
+			.filter(p -> !viewCounts.containsKey(p.getId()))
+			.toList();
+		if (!viewMissProducts.isEmpty()) {
+			viewCounts.putAll(writeViewCountCache(viewMissProducts));
+		}
+
 		List<ProductResponseDto> content = page.getContent().stream()
-			.map(ProductResponseDto::from)
+			.map(p -> ProductResponseDto.from(
+				p,
+				sellerNameMap.getOrDefault(p.getSellerId(), ""),
+				likeCounts.getOrDefault(p.getId(), 0L),
+				viewCounts.getOrDefault(p.getId(), p.getViewCount())))
 			.toList();
 
-		return SearchProductResponseDto.fromEs(page, content);
+		return SearchProductResponseDto.from(page, content);
 	}
 
 	@Override
@@ -189,25 +222,39 @@ public class ProductService implements ProductUseCase {
 			page = productSearchRepository.searchByKeywordAndSellerId(requestDto.title(), sellerIdStr, pageable);
 		}
 
+		List<UUID> productIds = page.getContent().stream()
+			.map(doc -> UUID.fromString(doc.getId()))
+			.toList();
+
+		Map<UUID, Long> likeCounts = batchGetCounts(productIds, LIKE_COUNT_KEY);
+		Map<UUID, Long> viewCounts = batchGetCounts(productIds, VIEW_COUNT_KEY);
+
 		List<ProductResponseDto> content = page.getContent().stream()
-			.map(ProductResponseDto::from)
+			.map(doc -> {
+				UUID id = UUID.fromString(doc.getId());
+				return ProductResponseDto.from(doc, likeCounts.getOrDefault(id, 0L), viewCounts.getOrDefault(id, 0L));
+			})
 			.toList();
 
 		return SearchProductResponseDto.fromEs(page, content);
 	}
 
+	// 정적 데이터(DB) + 동적 데이터(Redis) 조합
 	@Override
 	public ProductResponseDto searchById(UUID productId, UUID userId) {
 		Product product = findByIdOrThrow(productId);
-
 		UserResponseDto seller = findBySellerIdOrThrow(product.getSellerId());
+
+		long likeCount = favoriteUseCase.getLikeCount(productId);
+		long viewCount = incrementAndGetViewCount(product);
+
 		if (userId != null) {
 			log.info("상품 조회 이벤트 발행 준비: userId={}, productId={}", userId, productId);
 			publisher.publishEvent(ProductViewedEvent.of(userId, productId));
 			log.info("상품 조회 이벤트 발행 완료: userId={}, productId={}", userId, productId);
 		}
 
-		return ProductResponseDto.from(product, seller.name());
+		return ProductResponseDto.from(product, seller.name(), likeCount, viewCount);
 	}
 
 	@Override
@@ -217,7 +264,6 @@ public class ProductService implements ProductUseCase {
 	}
 
 	@Override
-	// 해당 상품 보유자인지 확인
 	public Product matchProductAndSellerId(UUID productId, UUID sellerId) {
 		return productRepository.findByIdAndSellerId(productId, sellerId)
 			.orElseThrow(() -> new BusinessException(CommonErrorCode.MATCH_FAIL));
@@ -229,9 +275,7 @@ public class ProductService implements ProductUseCase {
 			return List.of();
 		}
 
-		List<UUID> distinctProductIds = productIds.stream()
-			.distinct()
-			.toList();
+		List<UUID> distinctProductIds = productIds.stream().distinct().toList();
 
 		Map<UUID, Product> productMap = productRepository.findAllByIds(distinctProductIds).stream()
 			.collect(Collectors.toMap(Product::getId, product -> product));
@@ -247,9 +291,31 @@ public class ProductService implements ProductUseCase {
 	public SearchProductResponseDto filterByCategoryAndRegion(CategoryType category, RegionType region, int page, int size) {
 		Pageable pageable = PageRequest.of(page, size);
 		Page<Product> result = productRepository.findByCategoryAndRegion(category, region, pageable);
-		List<ProductResponseDto> content = result.getContent().stream()
-			.map(p -> ProductResponseDto.from(p, ""))
+
+		List<UUID> productIds = result.getContent().stream().map(Product::getId).toList();
+		Map<UUID, Long> likeCounts = batchGetCounts(productIds, LIKE_COUNT_KEY);
+		Map<UUID, Long> viewCounts = batchGetCounts(productIds, VIEW_COUNT_KEY);
+
+		List<UUID> likeMissIds = productIds.stream().filter(id -> !likeCounts.containsKey(id)).toList();
+		if (!likeMissIds.isEmpty()) {
+			likeCounts.putAll(favoriteUseCase.getLikeCountBatch(likeMissIds));
+		}
+
+		List<Product> viewMissProducts = result.getContent().stream()
+			.filter(p -> !viewCounts.containsKey(p.getId()))
 			.toList();
+		if (!viewMissProducts.isEmpty()) {
+			viewCounts.putAll(writeViewCountCache(viewMissProducts));
+		}
+
+		List<ProductResponseDto> content = result.getContent().stream()
+			.map(p -> ProductResponseDto.from(
+				p,
+				"",
+				likeCounts.getOrDefault(p.getId(), 0L),
+				viewCounts.getOrDefault(p.getId(), p.getViewCount())))
+			.toList();
+
 		return SearchProductResponseDto.from(result, content);
 	}
 
@@ -295,6 +361,105 @@ public class ProductService implements ProductUseCase {
 		return totalIndexed;
 	}
 
+	// 성능 비교용 - 상세 조회 시 DB UPDATE view_count (Redis INCR 없음)
+	@Override
+	@Transactional
+	public ProductResponseDto searchByIdNoCache(UUID productId) {
+		Product product = findByIdOrThrow(productId);
+		UserResponseDto seller = findBySellerIdOrThrow(product.getSellerId());
+		long likeCount = favoriteUseCase.getLikeCount(productId);
+
+		productRepository.incrementViewCount(productId);
+		long viewCount = product.getViewCount() + 1;
+
+		return ProductResponseDto.from(product, seller.name(), likeCount, viewCount);
+	}
+
+	// 성능 비교용 - Redis 없이 DB 직접 조회
+	@Override
+	public SearchProductResponseDto searchAllNoCache(SearchProductRequestDto requestDto) {
+		Pageable pageable = PageRequest.of(requestDto.thisPage(), requestDto.pageSize());
+
+		Page<Product> page;
+		if (requestDto.title() == null || requestDto.title().isBlank()) {
+			page = productRepository.findByStatusAndDeleteDtIsNull(ProductStatus.ENABLE, pageable);
+		} else {
+			page = productRepository.findByStatusAndTitleContainingAndDeleteDtIsNull(
+				ProductStatus.ENABLE, requestDto.title(), pageable);
+		}
+
+		List<UUID> productIds = page.getContent().stream().map(Product::getId).toList();
+		List<UUID> sellerIds = page.getContent().stream().map(Product::getSellerId).distinct().toList();
+
+		Map<UUID, String> sellerNameMap = sellerRepository.findSellerList(sellerIds)
+			.map(list -> list.stream().collect(Collectors.toMap(UserResponseDto::userId, UserResponseDto::name)))
+			.orElse(Map.of());
+
+		Map<UUID, Long> likeCounts = favoriteUseCase.getLikeCountBatchNoCache(productIds);
+
+		List<ProductResponseDto> content = page.getContent().stream()
+			.map(p -> ProductResponseDto.from(
+				p,
+				sellerNameMap.getOrDefault(p.getSellerId(), ""),
+				likeCounts.getOrDefault(p.getId(), 0L),
+				p.getViewCount()))
+			.toList();
+
+		return SearchProductResponseDto.from(page, content);
+	}
+
+	// Redis view_count: 없으면 DB값으로 초기화 후 INCR
+	private long incrementAndGetViewCount(Product product) {
+		String key = VIEW_COUNT_KEY + product.getId();
+		try {
+			if (Boolean.FALSE.equals(redisTemplate.hasKey(key))) {
+				redisTemplate.opsForValue().setIfAbsent(key, String.valueOf(product.getViewCount()));
+			}
+			Long count = redisTemplate.opsForValue().increment(key);
+			return count != null ? count : product.getViewCount();
+		} catch (Exception e) {
+			log.warn("Redis view_count INCR 실패 (productId={}): {}", product.getId(), e.getMessage());
+			return product.getViewCount();
+		}
+	}
+
+	private Map<UUID, Long> writeViewCountCache(List<Product> products) {
+		Map<UUID, Long> result = products.stream()
+			.collect(Collectors.toMap(Product::getId, Product::getViewCount));
+		try {
+			result.forEach((id, count) ->
+				redisTemplate.opsForValue().setIfAbsent(VIEW_COUNT_KEY + id, String.valueOf(count)));
+		} catch (Exception e) {
+			log.warn("Redis view_count write-through 실패: {}", e.getMessage());
+		}
+		return result;
+	}
+
+	// Redis multiGet으로 카운터 배치 조회 (목록 조회 N+1 방지)
+	private Map<UUID, Long> batchGetCounts(List<UUID> productIds, String keyPrefix) {
+		if (productIds.isEmpty()) {
+			return new HashMap<>();
+		}
+		List<String> keys = productIds.stream().map(id -> keyPrefix + id).toList();
+		try {
+			List<String> values = redisTemplate.opsForValue().multiGet(keys);
+			if (values == null) {
+				return new HashMap<>();
+			}
+			Map<UUID, Long> result = new HashMap<>();
+			for (int i = 0; i < productIds.size(); i++) {
+				String value = values.get(i);
+				if (value != null) {
+					result.put(productIds.get(i), Long.parseLong(value));
+				}
+			}
+			return result;
+		} catch (Exception e) {
+			log.warn("Redis batch count 조회 실패: {}", e.getMessage());
+			return new HashMap<>();
+		}
+	}
+
 	private void saveEsOutbox(String aggregateId, EsEventType eventType, Object message) {
 		try {
 			String payload = objectMapper.writeValueAsString(message);
@@ -314,12 +479,8 @@ public class ProductService implements ProductUseCase {
 		saveEsOutbox(productId, EsEventType.ES_DELETE, ProductEsIndexMessage.delete(productId));
 	}
 
-	// 로그인 계정 여부
 	private UserResponseDto findBySellerIdOrThrow(UUID sellerId) {
-		UserResponseDto sellerInfo = sellerRepository.findSeller(sellerId)
+		return sellerRepository.findSeller(sellerId)
 			.orElseThrow(() -> new BusinessException(CommonErrorCode.SELLER_NOT_FOUND));
-
-		return sellerInfo;
 	}
-
 }

--- a/service/product/src/main/java/jabaclass/product/application/usecase/FavoriteUseCase.java
+++ b/service/product/src/main/java/jabaclass/product/application/usecase/FavoriteUseCase.java
@@ -1,15 +1,23 @@
 package jabaclass.product.application.usecase;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import jabaclass.product.presentation.dto.response.FavoritesResponseDto;
 
 public interface FavoriteUseCase {
 
-	FavoritesResponseDto createFavorite(int quantity, UUID scheduleId, UUID userId);
+	FavoritesResponseDto createFavorite(UUID productId, UUID userId);
 
 	void deleteFavorite(UUID favoriteId, UUID userId);
 
 	List<FavoritesResponseDto> findByUserIdAndDeleteDtIsNull(UUID userId);
+
+	long getLikeCount(UUID productId);
+
+	Map<UUID, Long> getLikeCountBatch(List<UUID> productIds);
+
+	// 성능 비교용 - Redis 없이 DB 직접 조회
+	Map<UUID, Long> getLikeCountBatchNoCache(List<UUID> productIds);
 }

--- a/service/product/src/main/java/jabaclass/product/application/usecase/ProductUseCase.java
+++ b/service/product/src/main/java/jabaclass/product/application/usecase/ProductUseCase.java
@@ -47,4 +47,10 @@ public interface ProductUseCase {
 	int migrateToEs();
 
 	SearchProductResponseDto filterByCategoryAndRegion(CategoryType category, RegionType region, int page, int size);
+
+	// 성능 비교용 - Redis 없이 DB 직접 조회
+	SearchProductResponseDto searchAllNoCache(SearchProductRequestDto requestDto);
+
+	// 성능 비교용 - 상세 조회 시 DB UPDATE view_count
+	ProductResponseDto searchByIdNoCache(UUID productId);
 }

--- a/service/product/src/main/java/jabaclass/product/common/exception/CommonErrorCode.java
+++ b/service/product/src/main/java/jabaclass/product/common/exception/CommonErrorCode.java
@@ -58,6 +58,8 @@ public enum CommonErrorCode {
 	NOT_BUY_USER(HttpStatus.NOT_FOUND, "예약자가 존재하지 않습니다."),
 	// 404 본인 즐겨찾기가 아닙니다.
 	NOT_MATCH_USER_LIKE(HttpStatus.NOT_FOUND, "본인의 즐겨찾기가 아닙니다."),
+	// 409 이미 찜한 상품입니다.
+	ALREADY_LIKED(HttpStatus.CONFLICT, "이미 찜한 상품입니다."),
 	// 404 본인 즐겨찾기가 아닙니다.
 	NOT_MATCH_USER_REVIEW(HttpStatus.NOT_FOUND, "본인의 리뷰가 아닙니다."),
 	// 404 리뷰가 존재하지 않습니다.

--- a/service/product/src/main/java/jabaclass/product/config/RedisConfig.java
+++ b/service/product/src/main/java/jabaclass/product/config/RedisConfig.java
@@ -1,0 +1,15 @@
+package jabaclass.product.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+		return new StringRedisTemplate(connectionFactory);
+	}
+}

--- a/service/product/src/main/java/jabaclass/product/domain/model/Favorite.java
+++ b/service/product/src/main/java/jabaclass/product/domain/model/Favorite.java
@@ -19,13 +19,10 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "products_likes", schema = "public")
 public class Favorite extends EntityBase {
 
-	@Column(name = "product_schedule_id", nullable = false)
-	private UUID productScheduleId;
+	@Column(name = "product_id", nullable = false)
+	private UUID productId;
 
 	@Column(name = "user_id", updatable = false, nullable = false)
 	private UUID userId;
-
-	@Column(nullable = false)
-	private int quantity;
 
 }

--- a/service/product/src/main/java/jabaclass/product/domain/model/Product.java
+++ b/service/product/src/main/java/jabaclass/product/domain/model/Product.java
@@ -87,6 +87,10 @@ public class Product extends EntityBase {
 	@Column(nullable = false, length = 20)
 	private RegionType region;
 
+	@Builder.Default
+	@Column(name = "view_count", nullable = false)
+	private long viewCount = 0L;
+
 	@PrePersist
 	public void prePersist() {
 		if (this.status == null) {
@@ -157,6 +161,10 @@ public class Product extends EntityBase {
 
 	public void changeRegion(RegionType region) {
 		this.region = region;
+	}
+
+	public void syncViewCount(long viewCount) {
+		this.viewCount = viewCount;
 	}
 
 }

--- a/service/product/src/main/java/jabaclass/product/domain/repository/FavoriteRepository.java
+++ b/service/product/src/main/java/jabaclass/product/domain/repository/FavoriteRepository.java
@@ -1,6 +1,7 @@
 package jabaclass.product.domain.repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import jabaclass.product.domain.model.Favorite;
@@ -9,7 +10,15 @@ public interface FavoriteRepository {
 
 	Favorite save(Favorite favorite);
 
-	List<Favorite> findByUserIdAndDeleteDtIsNull(UUID id);
+	List<Favorite> findByUserIdAndDeleteDtIsNull(UUID userId);
 
 	Favorite findByIdAndUserIdAndDeleteDtIsNull(UUID favoriteId, UUID userId);
+
+	Favorite findByUserIdAndProductIdAndDeleteDtIsNull(UUID userId, UUID productId);
+
+	long countByProductIdAndDeleteDtIsNull(UUID productId);
+
+	Map<UUID, Long> countAllGroupByProductId();
+
+	Map<UUID, Long> countGroupByProductIdIn(List<UUID> productIds);
 }

--- a/service/product/src/main/java/jabaclass/product/domain/repository/ProductRepository.java
+++ b/service/product/src/main/java/jabaclass/product/domain/repository/ProductRepository.java
@@ -37,4 +37,8 @@ public interface ProductRepository {
 	Page<Product> findAllByDeleteDtIsNull(Pageable pageable);
 
 	Page<Product> findByCategoryAndRegion(CategoryType category, RegionType region, Pageable pageable);
+
+	void updateViewCount(UUID productId, long viewCount);
+
+	void incrementViewCount(UUID productId);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/FavoriteJpaRepository.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/FavoriteJpaRepository.java
@@ -4,12 +4,35 @@ import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import jabaclass.product.infrastructure.persistence.dto.ProductLikeCountDto;
 
 import jabaclass.product.domain.model.Favorite;
 
 public interface FavoriteJpaRepository extends JpaRepository<Favorite, UUID> {
 
-	List<Favorite> findByUserIdAndDeleteDtIsNull(UUID id);
+	List<Favorite> findByUserIdAndDeleteDtIsNull(UUID userId);
 
 	Favorite findByIdAndUserIdAndDeleteDtIsNull(UUID favoriteId, UUID userId);
+
+	Favorite findByUserIdAndProductIdAndDeleteDtIsNull(UUID userId, UUID productId);
+
+	long countByProductIdAndDeleteDtIsNull(UUID productId);
+
+	@Query("""
+		SELECT new jabaclass.product.infrastructure.persistence.dto.ProductLikeCountDto(f.productId, COUNT(f))
+		FROM Favorite f
+		WHERE f.deleteDt IS NULL
+		GROUP BY f.productId
+		""")
+	List<ProductLikeCountDto> countGroupByProductId();
+
+	@Query("""
+		SELECT new jabaclass.product.infrastructure.persistence.dto.ProductLikeCountDto(f.productId, COUNT(f))
+		FROM Favorite f
+		WHERE f.productId IN :productIds AND f.deleteDt IS NULL
+		GROUP BY f.productId
+		""")
+	List<ProductLikeCountDto> countGroupByProductIdIn(List<UUID> productIds);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/FavoriteRepositoryAdapter.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/FavoriteRepositoryAdapter.java
@@ -1,12 +1,15 @@
 package jabaclass.product.infrastructure.persistence;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
 
 import jabaclass.product.domain.model.Favorite;
 import jabaclass.product.domain.repository.FavoriteRepository;
+import jabaclass.product.infrastructure.persistence.dto.ProductLikeCountDto;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -21,12 +24,34 @@ public class FavoriteRepositoryAdapter implements FavoriteRepository {
 	}
 
 	@Override
-	public List<Favorite> findByUserIdAndDeleteDtIsNull(UUID id) {
-		return favoriteJpaRepository.findByUserIdAndDeleteDtIsNull(id);
+	public List<Favorite> findByUserIdAndDeleteDtIsNull(UUID userId) {
+		return favoriteJpaRepository.findByUserIdAndDeleteDtIsNull(userId);
 	}
 
 	@Override
 	public Favorite findByIdAndUserIdAndDeleteDtIsNull(UUID favoriteId, UUID userId) {
 		return favoriteJpaRepository.findByIdAndUserIdAndDeleteDtIsNull(favoriteId, userId);
+	}
+
+	@Override
+	public Favorite findByUserIdAndProductIdAndDeleteDtIsNull(UUID userId, UUID productId) {
+		return favoriteJpaRepository.findByUserIdAndProductIdAndDeleteDtIsNull(userId, productId);
+	}
+
+	@Override
+	public long countByProductIdAndDeleteDtIsNull(UUID productId) {
+		return favoriteJpaRepository.countByProductIdAndDeleteDtIsNull(productId);
+	}
+
+	@Override
+	public Map<UUID, Long> countAllGroupByProductId() {
+		return favoriteJpaRepository.countGroupByProductId().stream()
+			.collect(Collectors.toMap(ProductLikeCountDto::productId, ProductLikeCountDto::count));
+	}
+
+	@Override
+	public Map<UUID, Long> countGroupByProductIdIn(List<UUID> productIds) {
+		return favoriteJpaRepository.countGroupByProductIdIn(productIds).stream()
+			.collect(Collectors.toMap(ProductLikeCountDto::productId, ProductLikeCountDto::count));
 	}
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductJpaRepository.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductJpaRepository.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -42,4 +43,12 @@ public interface ProductJpaRepository extends JpaRepository<Product, UUID> {
 		@Param("region") RegionType region,
 		@Param("status") ProductStatus status,
 		Pageable pageable);
+
+	@Modifying
+	@Query("UPDATE Product p SET p.viewCount = :viewCount WHERE p.id = :productId")
+	void updateViewCount(@Param("productId") UUID productId, @Param("viewCount") long viewCount);
+
+	@Modifying
+	@Query("UPDATE Product p SET p.viewCount = p.viewCount + 1 WHERE p.id = :productId")
+	void incrementViewCount(@Param("productId") UUID productId);
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductRepositoryAdapter.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/ProductRepositoryAdapter.java
@@ -68,4 +68,14 @@ public class ProductRepositoryAdapter implements ProductRepository {
 		return productJpaRepository.findByCategoryAndRegion(category, region, ProductStatus.ENABLE, pageable);
 	}
 
+	@Override
+	public void updateViewCount(UUID productId, long viewCount) {
+		productJpaRepository.updateViewCount(productId, viewCount);
+	}
+
+	@Override
+	public void incrementViewCount(UUID productId) {
+		productJpaRepository.incrementViewCount(productId);
+	}
+
 }

--- a/service/product/src/main/java/jabaclass/product/infrastructure/persistence/dto/ProductLikeCountDto.java
+++ b/service/product/src/main/java/jabaclass/product/infrastructure/persistence/dto/ProductLikeCountDto.java
@@ -1,0 +1,6 @@
+package jabaclass.product.infrastructure.persistence.dto;
+
+import java.util.UUID;
+
+public record ProductLikeCountDto(UUID productId, long count) {
+}

--- a/service/product/src/main/java/jabaclass/product/presentation/controller/FavoritesRestController.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/controller/FavoritesRestController.java
@@ -30,19 +30,20 @@ public class FavoritesRestController implements FavoritesOpenApi {
 	private final FavoriteUseCase favoriteUseCase;
 
 	@Override
-	@PostMapping("/{scheduleId}/likes")
-	public ResponseEntity<ApiResponseDto<FavoritesResponseDto>> create(@RequestParam int quantity,
-		@PathVariable UUID scheduleId,
+	@PostMapping("/{productId}/likes")
+	public ResponseEntity<ApiResponseDto<FavoritesResponseDto>> create(
+		@PathVariable UUID productId,
 		@CurrentUser UUID userId) {
-		FavoritesResponseDto response = favoriteUseCase.createFavorite(quantity, scheduleId, userId);
+		FavoritesResponseDto response = favoriteUseCase.createFavorite(productId, userId);
 
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(ApiResponseDto.success(HttpStatus.CREATED, "성공적으로 등록 되었습니다.", response));
 	}
 
 	@Override
-	@DeleteMapping("/{scheduleId}/likes")
-	public ResponseEntity<ApiResponseDto<FavoritesResponseDto>> delete(@RequestParam UUID likeId,
+	@DeleteMapping("/{productId}/likes")
+	public ResponseEntity<ApiResponseDto<FavoritesResponseDto>> delete(
+		@RequestParam UUID likeId,
 		@CurrentUser UUID userId) {
 		favoriteUseCase.deleteFavorite(likeId, userId);
 

--- a/service/product/src/main/java/jabaclass/product/presentation/controller/ProductRestController.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/controller/ProductRestController.java
@@ -117,6 +117,23 @@ public class ProductRestController implements ProductOpenApi {
 			.body(ApiResponseDto.success(HttpStatus.OK, "성공적으로 검색이 되었습니다.", response));
 	}
 
+	// 성능 비교용 - 상세 조회 DB UPDATE view_count
+	@GetMapping("/{productId}/no-cache")
+	public ResponseEntity<ApiResponseDto<ProductResponseDto>> searchByIdNoCache(@PathVariable UUID productId) {
+		ProductResponseDto response = productUseCase.searchByIdNoCache(productId);
+		return ResponseEntity.ok()
+			.body(ApiResponseDto.success(HttpStatus.OK, "성공적으로 조회되었습니다.", response));
+	}
+
+	// 성능 비교용 - Redis 없이 DB 직접 조회
+	@GetMapping("/no-cache")
+	public ResponseEntity<ApiResponseDto<SearchProductResponseDto>> searchAllNoCache(
+		@ModelAttribute SearchProductRequestDto request) {
+		SearchProductResponseDto response = productUseCase.searchAllNoCache(request);
+		return ResponseEntity.ok()
+			.body(ApiResponseDto.success(HttpStatus.OK, "성공적으로 조회되었습니다.", response));
+	}
+
 	@GetMapping("/filter")
 	public ResponseEntity<ApiResponseDto<SearchProductResponseDto>> filterByCategoryAndRegion(
 		@RequestParam CategoryType category,

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/response/FavoritesResponseDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/response/FavoritesResponseDto.java
@@ -1,26 +1,17 @@
 package jabaclass.product.presentation.dto.response;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jabaclass.product.domain.model.Favorite;
 import jabaclass.product.domain.model.Product;
-import jabaclass.product.domain.model.Schedule;
 
-@Schema(description = "즐겨 찾기")
+@Schema(description = "즐겨찾기")
 public record FavoritesResponseDto(
 
 	@Schema(description = "즐겨찾기 Id", example = "550e8400-e29b-41d4-a716-446655440000")
 	UUID id,
-
-	@Schema(description = "상품 일정 Id", example = "550e8400-e29b-41d4-a716-446655440000")
-	UUID productScheduleId,
-
-	@Schema(description = "수량", example = "2")
-	int quantity,
 
 	@Schema(description = "상품 Id", example = "550e8400-e29b-41d4-a716-446655440000")
 	UUID productId,
@@ -32,45 +23,26 @@ public record FavoritesResponseDto(
 	String thumbnailPath,
 
 	@Schema(description = "상품 가격", example = "35000")
-	BigDecimal price,
-
-	@Schema(description = "일정 날짜", example = "2026-05-01")
-	LocalDate scheduleDt,
-
-	@Schema(description = "시작 시간", example = "10:00")
-	LocalTime startTime,
-
-	@Schema(description = "종료 시간", example = "12:00")
-	LocalTime endTime
+	BigDecimal price
 
 ) {
 	public static FavoritesResponseDto from(Favorite favorite) {
 		return new FavoritesResponseDto(
 			favorite.getId(),
-			favorite.getProductScheduleId(),
-			favorite.getQuantity(),
-			null,
-			null,
-			null,
-			null,
+			favorite.getProductId(),
 			null,
 			null,
 			null
 		);
 	}
 
-	public static FavoritesResponseDto from(Favorite favorite, Schedule schedule, Product product) {
+	public static FavoritesResponseDto from(Favorite favorite, Product product) {
 		return new FavoritesResponseDto(
 			favorite.getId(),
-			favorite.getProductScheduleId(),
-			favorite.getQuantity(),
 			product.getId(),
 			product.getTitle(),
 			product.getThumbnailPath(),
-			product.getPrice(),
-			schedule.getScheduleDt(),
-			schedule.getStartTime(),
-			schedule.getEndTime()
+			product.getPrice()
 		);
 	}
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/dto/response/ProductResponseDto.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/dto/response/ProductResponseDto.java
@@ -59,10 +59,16 @@ public record ProductResponseDto(
 	BigDecimal latitude,
 
 	@Schema(description = "경도", example = "127.1110")
-	BigDecimal longitude
+	BigDecimal longitude,
+
+	@Schema(description = "좋아요 수", example = "42")
+	long likeCount,
+
+	@Schema(description = "조회수", example = "1024")
+	long viewCount
 ) {
 
-	public static ProductResponseDto from(Product product, String sellerName) {
+	public static ProductResponseDto from(Product product, String sellerName, long likeCount, long viewCount) {
 		List<ProductImageItem> images = product.getDescriptionImages();
 		List<String> imagePaths = images == null ? List.of()
 			: images.stream().map(ProductImageItem::storagePath).toList();
@@ -83,11 +89,18 @@ public record ProductResponseDto(
 			product.getDetailAddress(),
 			product.getZonecode(),
 			product.getLatitude(),
-			product.getLongitude()
+			product.getLongitude(),
+			likeCount,
+			viewCount
 		);
 	}
 
-	public static ProductResponseDto from(ProductDocument document) {
+	// 생성/수정 응답용 (카운터 불필요)
+	public static ProductResponseDto from(Product product, String sellerName) {
+		return from(product, sellerName, 0L, 0L);
+	}
+
+	public static ProductResponseDto from(ProductDocument document, long likeCount, long viewCount) {
 		return new ProductResponseDto(
 			UUID.fromString(document.getId()),
 			document.getSellerName(),
@@ -104,8 +117,14 @@ public record ProductResponseDto(
 			null,
 			null,
 			null,
-			null
+			null,
+			likeCount,
+			viewCount
 		);
 	}
 
+	// 목록 조회 시 Redis miss인 경우 0으로 반환
+	public static ProductResponseDto from(ProductDocument document) {
+		return from(document, 0L, 0L);
+	}
 }

--- a/service/product/src/main/java/jabaclass/product/presentation/openapi/FavoritesOpenApi.java
+++ b/service/product/src/main/java/jabaclass/product/presentation/openapi/FavoritesOpenApi.java
@@ -25,7 +25,7 @@ public interface FavoritesOpenApi {
 		)
 	)
 	@CommonErrorResponses
-	ResponseEntity<ApiResponseDto<FavoritesResponseDto>> create(int quantity, UUID scheduleId, UUID userId);
+	ResponseEntity<ApiResponseDto<FavoritesResponseDto>> create(UUID productId, UUID userId);
 
 	@Operation(summary = "즐겨찾기 해제", description = "즐겨찾기를 해제 합니다.")
 	@ApiResponse(

--- a/service/product/src/main/resources/application-dev.yml
+++ b/service/product/src/main/resources/application-dev.yml
@@ -9,6 +9,11 @@ spring:
   elasticsearch:
     uris: ${ES_URIS:http://localhost:9200}
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   datasource:
     url: jdbc:mysql://${MYSQL_HOST:localhost}:${MYSQL_PORT:3306}/productdb?serverTimezone=UTC&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/service/product/src/test/java/jabaclass/product/FavoriteTest.java
+++ b/service/product/src/test/java/jabaclass/product/FavoriteTest.java
@@ -5,11 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,26 +18,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import jabaclass.product.application.exception.BusinessException;
 import jabaclass.product.application.service.FavoriteService;
-import jabaclass.product.application.usecase.FavoriteUseCase;
-import jabaclass.product.common.exception.ApiResponseDto;
 import jabaclass.product.common.exception.CommonErrorCode;
 import jabaclass.product.domain.model.Favorite;
 import jabaclass.product.domain.model.Product;
-import jabaclass.product.domain.model.Schedule;
 import jabaclass.product.domain.model.status.ProductStatus;
-import jabaclass.product.domain.model.status.ReservedStatus;
 import jabaclass.product.domain.repository.FavoriteRepository;
 import jabaclass.product.domain.repository.ProductRepository;
-import jabaclass.product.domain.repository.ScheduleRepository;
 import jabaclass.product.infrastructure.event.dto.ProductWishlistedEvent;
-import jabaclass.product.presentation.controller.FavoritesRestController;
 import jabaclass.product.presentation.dto.response.FavoritesResponseDto;
 
 @ExtendWith(MockitoExtension.class)
@@ -46,14 +40,8 @@ class FavoriteTest {
 	@InjectMocks
 	private FavoriteService favoriteService;
 
-	@InjectMocks
-	private FavoritesRestController favoritesRestController;
-
 	@Mock
 	private FavoriteRepository favoriteRepository;
-
-	@Mock
-	private ScheduleRepository scheduleRepository;
 
 	@Mock
 	private ProductRepository productRepository;
@@ -62,196 +50,81 @@ class FavoriteTest {
 	private ApplicationEventPublisher publisher;
 
 	@Mock
-	private FavoriteUseCase favoriteUseCase;
+	private StringRedisTemplate redisTemplate;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
 
 	private static final UUID USER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-	private static final UUID SCHEDULE_ID = UUID.fromString("223e4567-e89b-12d3-a456-426614174000");
-	private static final UUID FAVORITE_ID = UUID.fromString("323e4567-e89b-12d3-a456-426614174000");
 	private static final UUID PRODUCT_ID = UUID.fromString("423e4567-e89b-12d3-a456-426614174000");
+	private static final UUID FAVORITE_ID = UUID.fromString("323e4567-e89b-12d3-a456-426614174000");
 
 	private Favorite favorite;
+	private Product product;
 
 	@BeforeEach
 	void setUp() {
 		favorite = Favorite.builder()
-			.productScheduleId(SCHEDULE_ID)
+			.productId(PRODUCT_ID)
 			.userId(USER_ID)
-			.quantity(2)
 			.build();
 		ReflectionTestUtils.setField(favorite, "id", FAVORITE_ID);
+
+		product = Product.builder()
+			.sellerId(USER_ID)
+			.title("테스트 상품")
+			.thumbnailPath("/images/test.jpg")
+			.price(BigDecimal.valueOf(35000))
+			.maxCapacity(10)
+			.description("테스트 설명")
+			.status(ProductStatus.ENABLE)
+			.roadAddress("서울시 강남구")
+			.latitude(BigDecimal.valueOf(37.5))
+			.longitude(BigDecimal.valueOf(127.0))
+			.build();
+		ReflectionTestUtils.setField(product, "id", PRODUCT_ID);
+
+		lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 	}
 
 	@Test
 	void 즐겨찾기를_생성한다() {
-		Schedule schedule = Schedule.builder()
-			.productId(PRODUCT_ID)
-			.scheduleDt(LocalDate.of(2026, 5, 1))
-			.startTime(LocalTime.of(10, 0))
-			.endTime(LocalTime.of(12, 0))
-			.status(ReservedStatus.AVAILABLE)
-			.capacity(10)
-			.build();
-		ReflectionTestUtils.setField(schedule, "id", SCHEDULE_ID);
-
-		given(scheduleRepository.findByIdAndDeleteDtIsNull(SCHEDULE_ID)).willReturn(java.util.Optional.of(schedule));
+		given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.of(product));
+		given(favoriteRepository.findByUserIdAndProductIdAndDeleteDtIsNull(USER_ID, PRODUCT_ID)).willReturn(null);
 		given(favoriteRepository.save(any(Favorite.class))).willAnswer(invocation -> {
 			Favorite saved = invocation.getArgument(0);
 			ReflectionTestUtils.setField(saved, "id", FAVORITE_ID);
 			return saved;
 		});
+		given(redisTemplate.hasKey(any())).willReturn(true);
+		given(valueOperations.increment(any())).willReturn(1L);
 
-		FavoritesResponseDto result = favoriteService.createFavorite(2, SCHEDULE_ID, USER_ID);
+		FavoritesResponseDto result = favoriteService.createFavorite(PRODUCT_ID, USER_ID);
 
 		assertThat(result.id()).isEqualTo(FAVORITE_ID);
-		assertThat(result.productScheduleId()).isEqualTo(SCHEDULE_ID);
-		assertThat(result.quantity()).isEqualTo(2);
+		assertThat(result.productId()).isEqualTo(PRODUCT_ID);
 		then(publisher).should().publishEvent(any(ProductWishlistedEvent.class));
+	}
+
+	@Test
+	void 이미_찜한_상품은_다시_찜할_수_없다() {
+		given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.of(product));
+		given(favoriteRepository.findByUserIdAndProductIdAndDeleteDtIsNull(USER_ID, PRODUCT_ID)).willReturn(favorite);
+
+		assertThatThrownBy(() -> favoriteService.createFavorite(PRODUCT_ID, USER_ID))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage(CommonErrorCode.ALREADY_LIKED.getMessage());
 	}
 
 	@Test
 	void 즐겨찾기를_삭제한다() {
 		given(favoriteRepository.findByIdAndUserIdAndDeleteDtIsNull(FAVORITE_ID, USER_ID)).willReturn(favorite);
+		given(redisTemplate.hasKey(any())).willReturn(true);
+		given(valueOperations.decrement(any())).willReturn(0L);
 
 		favoriteService.deleteFavorite(FAVORITE_ID, USER_ID);
 
 		assertThat(favorite.getDeleteDt()).isNotNull();
-	}
-
-	@Test
-	void 찜목록_조회_성공_상품정보_포함() {
-		// given
-		Schedule schedule = Schedule.builder()
-			.productId(PRODUCT_ID)
-			.scheduleDt(LocalDate.of(2026, 5, 1))
-			.startTime(LocalTime.of(10, 0))
-			.endTime(LocalTime.of(12, 0))
-			.status(ReservedStatus.AVAILABLE)
-			.capacity(10)
-			.build();
-		ReflectionTestUtils.setField(schedule, "id", SCHEDULE_ID);
-
-		Product product = Product.builder()
-			.sellerId(USER_ID)
-			.title("테스트 상품")
-			.thumbnailPath("/images/test.jpg")
-			.price(BigDecimal.valueOf(35000))
-			.maxCapacity(10)
-			.description("테스트 설명")
-			.status(ProductStatus.ENABLE)
-			.roadAddress("서울시 강남구")
-			.latitude(BigDecimal.valueOf(37.5))
-			.longitude(BigDecimal.valueOf(127.0))
-			.build();
-		ReflectionTestUtils.setField(product, "id", PRODUCT_ID);
-
-		given(favoriteRepository.findByUserIdAndDeleteDtIsNull(USER_ID)).willReturn(List.of(favorite));
-		given(scheduleRepository.findAllByIdInAndDeleteDtIsNull(List.of(SCHEDULE_ID))).willReturn(List.of(schedule));
-		given(productRepository.findAllByIdsAndDeleteDtIsNull(List.of(PRODUCT_ID))).willReturn(List.of(product));
-
-		// when
-		List<FavoritesResponseDto> result = favoriteService.findByUserIdAndDeleteDtIsNull(USER_ID);
-
-		// then
-		assertThat(result).hasSize(1);
-		FavoritesResponseDto dto = result.get(0);
-		assertThat(dto.id()).isEqualTo(FAVORITE_ID);
-		assertThat(dto.productScheduleId()).isEqualTo(SCHEDULE_ID);
-		assertThat(dto.quantity()).isEqualTo(2);
-		assertThat(dto.productId()).isEqualTo(PRODUCT_ID);
-		assertThat(dto.productTitle()).isEqualTo("테스트 상품");
-		assertThat(dto.thumbnailPath()).isEqualTo("/images/test.jpg");
-		assertThat(dto.price()).isEqualByComparingTo(BigDecimal.valueOf(35000));
-		assertThat(dto.scheduleDt()).isEqualTo(LocalDate.of(2026, 5, 1));
-		assertThat(dto.startTime()).isEqualTo(LocalTime.of(10, 0));
-		assertThat(dto.endTime()).isEqualTo(LocalTime.of(12, 0));
-	}
-
-	@Test
-	void 찜목록_조회_일정없음_해당항목_제외() {
-		// given
-		given(favoriteRepository.findByUserIdAndDeleteDtIsNull(USER_ID)).willReturn(List.of(favorite));
-		given(scheduleRepository.findAllByIdInAndDeleteDtIsNull(List.of(SCHEDULE_ID))).willReturn(List.of());
-		given(productRepository.findAllByIdsAndDeleteDtIsNull(List.of())).willReturn(List.of());
-
-		// when
-		List<FavoritesResponseDto> result = favoriteService.findByUserIdAndDeleteDtIsNull(USER_ID);
-
-		// then
-		assertThat(result).isEmpty();
-	}
-
-	@Test
-	void 찜목록_조회_상품없음_해당항목_제외() {
-		// given
-		Schedule schedule = Schedule.builder()
-			.productId(PRODUCT_ID)
-			.scheduleDt(LocalDate.of(2026, 5, 1))
-			.startTime(LocalTime.of(10, 0))
-			.endTime(LocalTime.of(12, 0))
-			.status(ReservedStatus.AVAILABLE)
-			.capacity(10)
-			.build();
-		ReflectionTestUtils.setField(schedule, "id", SCHEDULE_ID);
-
-		given(favoriteRepository.findByUserIdAndDeleteDtIsNull(USER_ID)).willReturn(List.of(favorite));
-		given(scheduleRepository.findAllByIdInAndDeleteDtIsNull(List.of(SCHEDULE_ID))).willReturn(List.of(schedule));
-		given(productRepository.findAllByIdsAndDeleteDtIsNull(List.of(PRODUCT_ID))).willReturn(List.of());
-
-		// when
-		List<FavoritesResponseDto> result = favoriteService.findByUserIdAndDeleteDtIsNull(USER_ID);
-
-		// then
-		assertThat(result).isEmpty();
-	}
-
-	@Test
-	void 찜목록_조회_여러건중_일부만_유효한_경우() {
-		// given
-		UUID scheduleId2 = UUID.fromString("523e4567-e89b-12d3-a456-426614174000");
-		UUID favoriteId2 = UUID.fromString("623e4567-e89b-12d3-a456-426614174000");
-
-		Favorite favorite2 = Favorite.builder()
-			.productScheduleId(scheduleId2)
-			.userId(USER_ID)
-			.quantity(1)
-			.build();
-		ReflectionTestUtils.setField(favorite2, "id", favoriteId2);
-
-		Schedule schedule = Schedule.builder()
-			.productId(PRODUCT_ID)
-			.scheduleDt(LocalDate.of(2026, 5, 1))
-			.startTime(LocalTime.of(10, 0))
-			.endTime(LocalTime.of(12, 0))
-			.status(ReservedStatus.AVAILABLE)
-			.capacity(10)
-			.build();
-		ReflectionTestUtils.setField(schedule, "id", SCHEDULE_ID);
-
-		Product product = Product.builder()
-			.sellerId(USER_ID)
-			.title("테스트 상품")
-			.thumbnailPath("/images/test.jpg")
-			.price(BigDecimal.valueOf(35000))
-			.maxCapacity(10)
-			.description("테스트 설명")
-			.status(ProductStatus.ENABLE)
-			.roadAddress("서울시 강남구")
-			.latitude(BigDecimal.valueOf(37.5))
-			.longitude(BigDecimal.valueOf(127.0))
-			.build();
-		ReflectionTestUtils.setField(product, "id", PRODUCT_ID);
-
-		given(favoriteRepository.findByUserIdAndDeleteDtIsNull(USER_ID)).willReturn(List.of(favorite, favorite2));
-		given(scheduleRepository.findAllByIdInAndDeleteDtIsNull(List.of(SCHEDULE_ID, scheduleId2))).willReturn(List.of(schedule));
-		given(productRepository.findAllByIdsAndDeleteDtIsNull(List.of(PRODUCT_ID))).willReturn(List.of(product));
-
-		// when
-		List<FavoritesResponseDto> result = favoriteService.findByUserIdAndDeleteDtIsNull(USER_ID);
-
-		// then
-		assertThat(result).hasSize(1);
-		assertThat(result.get(0).id()).isEqualTo(FAVORITE_ID);
-		assertThat(result.get(0).productTitle()).isEqualTo("테스트 상품");
 	}
 
 	@Test
@@ -264,36 +137,28 @@ class FavoriteTest {
 	}
 
 	@Test
-	void 즐겨찾기_생성_요청이_들어오면_컨트롤러가_유스케이스를_호출한다() {
-		FavoritesResponseDto response = FavoritesResponseDto.from(favorite);
-		given(favoriteUseCase.createFavorite(2, SCHEDULE_ID, USER_ID)).willReturn(response);
+	void 찜목록_조회_성공_상품정보_포함() {
+		given(favoriteRepository.findByUserIdAndDeleteDtIsNull(USER_ID)).willReturn(List.of(favorite));
+		given(productRepository.findAllByIdsAndDeleteDtIsNull(List.of(PRODUCT_ID))).willReturn(List.of(product));
 
-		ResponseEntity<ApiResponseDto<FavoritesResponseDto>> result = favoritesRestController.create(2, SCHEDULE_ID, USER_ID);
+		List<FavoritesResponseDto> result = favoriteService.findByUserIdAndDeleteDtIsNull(USER_ID);
 
-		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-		assertThat(result.getBody()).isNotNull();
-		assertThat(result.getBody().getData()).isEqualTo(response);
-		then(favoriteUseCase).should().createFavorite(2, SCHEDULE_ID, USER_ID);
+		assertThat(result).hasSize(1);
+		FavoritesResponseDto dto = result.get(0);
+		assertThat(dto.id()).isEqualTo(FAVORITE_ID);
+		assertThat(dto.productId()).isEqualTo(PRODUCT_ID);
+		assertThat(dto.productTitle()).isEqualTo("테스트 상품");
+		assertThat(dto.thumbnailPath()).isEqualTo("/images/test.jpg");
+		assertThat(dto.price()).isEqualByComparingTo(BigDecimal.valueOf(35000));
 	}
 
 	@Test
-	void 즐겨찾기_삭제_요청이_들어오면_컨트롤러가_유스케이스를_호출한다() {
-		ResponseEntity<ApiResponseDto<FavoritesResponseDto>> result = favoritesRestController.delete(FAVORITE_ID, USER_ID);
+	void 찜목록_조회_상품없음_해당항목_제외() {
+		given(favoriteRepository.findByUserIdAndDeleteDtIsNull(USER_ID)).willReturn(List.of(favorite));
+		given(productRepository.findAllByIdsAndDeleteDtIsNull(List.of(PRODUCT_ID))).willReturn(List.of());
 
-		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-		then(favoriteUseCase).should().deleteFavorite(FAVORITE_ID, USER_ID);
-	}
+		List<FavoritesResponseDto> result = favoriteService.findByUserIdAndDeleteDtIsNull(USER_ID);
 
-	@Test
-	void 즐겨찾기_목록_조회_요청이_들어오면_컨트롤러가_유스케이스를_호출한다() {
-		List<FavoritesResponseDto> response = List.of(FavoritesResponseDto.from(favorite));
-		given(favoriteUseCase.findByUserIdAndDeleteDtIsNull(USER_ID)).willReturn(response);
-
-		ResponseEntity<ApiResponseDto<List<FavoritesResponseDto>>> result = favoritesRestController.getList(USER_ID);
-
-		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(result.getBody()).isNotNull();
-		assertThat(result.getBody().getData()).hasSize(1);
-		then(favoriteUseCase).should().findByUserIdAndDeleteDtIsNull(USER_ID);
+		assertThat(result).isEmpty();
 	}
 }

--- a/service/product/src/test/java/jabaclass/product/FavoritesRestControllerTest.java
+++ b/service/product/src/test/java/jabaclass/product/FavoritesRestControllerTest.java
@@ -32,7 +32,7 @@ class FavoritesRestControllerTest {
 	@Mock
 	private FavoriteUseCase favoriteUseCase;
 
-	private static final UUID SCHEDULE_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+	private static final UUID PRODUCT_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 	private static final UUID FAVORITE_ID = UUID.fromString("223e4567-e89b-12d3-a456-426614174000");
 	private static final UUID USER_ID = UUID.fromString("323e4567-e89b-12d3-a456-426614174000");
 
@@ -41,9 +41,8 @@ class FavoritesRestControllerTest {
 	@BeforeEach
 	void setUp() {
 		favorite = Favorite.builder()
-			.productScheduleId(SCHEDULE_ID)
+			.productId(PRODUCT_ID)
 			.userId(USER_ID)
-			.quantity(2)
 			.build();
 		ReflectionTestUtils.setField(favorite, "id", FAVORITE_ID);
 	}
@@ -51,14 +50,14 @@ class FavoritesRestControllerTest {
 	@Test
 	void 즐겨찾기_생성_요청이_들어오면_유스케이스를_호출한다() {
 		FavoritesResponseDto response = FavoritesResponseDto.from(favorite);
-		given(favoriteUseCase.createFavorite(2, SCHEDULE_ID, USER_ID)).willReturn(response);
+		given(favoriteUseCase.createFavorite(PRODUCT_ID, USER_ID)).willReturn(response);
 
-		ResponseEntity<ApiResponseDto<FavoritesResponseDto>> result = favoritesRestController.create(2, SCHEDULE_ID, USER_ID);
+		ResponseEntity<ApiResponseDto<FavoritesResponseDto>> result = favoritesRestController.create(PRODUCT_ID, USER_ID);
 
 		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.CREATED);
 		assertThat(result.getBody()).isNotNull();
 		assertThat(result.getBody().getData()).isEqualTo(response);
-		then(favoriteUseCase).should().createFavorite(2, SCHEDULE_ID, USER_ID);
+		then(favoriteUseCase).should().createFavorite(PRODUCT_ID, USER_ID);
 	}
 
 	@Test

--- a/service/product/src/test/java/jabaclass/product/ProductCUDTest.java
+++ b/service/product/src/test/java/jabaclass/product/ProductCUDTest.java
@@ -21,20 +21,24 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jabaclass.product.application.acl.SellerRepository;
 import jabaclass.product.application.dto.FileConfirmResponse;
 import jabaclass.product.application.exception.BusinessException;
 import jabaclass.product.application.service.ProductService;
+import jabaclass.product.application.usecase.FavoriteUseCase;
 import jabaclass.product.application.usecase.ValidateFileUseCase;
 import jabaclass.product.common.exception.CommonErrorCode;
 import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.status.CategoryType;
 import jabaclass.product.domain.model.status.ProductStatus;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.repository.ProductRepository;
 import jabaclass.product.domain.repository.ProductSearchRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import jabaclass.product.infrastructure.acl.dto.response.UserResponseDto;
 import jabaclass.product.infrastructure.event.dto.ProductEventResponseDto;
 import jabaclass.product.infrastructure.outbox.OutboxEvent;
@@ -73,6 +77,12 @@ class ProductCUDTest {
 	@Mock
 	private ObjectMapper objectMapper;
 
+	@Mock
+	private StringRedisTemplate redisTemplate;
+
+	@Mock
+	private FavoriteUseCase favoriteUseCase;
+
 	private static final UUID SELLER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 	private static final UUID PRODUCT_ID = UUID.fromString("223e4567-e89b-12d3-a456-426614174000");
 	private static final BigDecimal PRICE = new BigDecimal("1000.50");
@@ -99,6 +109,8 @@ class ProductCUDTest {
 			.zonecode("13529")
 			.latitude(LATITUDE)
 			.longitude(LONGITUDE)
+			.category(CategoryType.SPORTS)
+			.region(RegionType.GANGNAM)
 			.build();
 		ReflectionTestUtils.setField(product, "id", PRODUCT_ID);
 	}
@@ -106,18 +118,10 @@ class ProductCUDTest {
 	@Test
 	void 상품_생성시_추가된_주소와_좌표_컬럼까지_저장한다() {
 		CreateProductRequestDto request = new CreateProductRequestDto(
-			SELLER_ID,
-			"테스트상품",
-			5,
-			"테스트 상품입니다.",
-			List.of(UUID.randomUUID()),
-			PRICE,
-			ProductStatus.ENABLE,
-			"경기 성남시 분당구 판교역로 166",
-			"카카오 판교 아지트 1층",
-			"13529",
-			LATITUDE,
-			LONGITUDE
+			SELLER_ID, "테스트상품", 5, "테스트 상품입니다.",
+			List.of(UUID.randomUUID()), PRICE, ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166", "카카오 판교 아지트 1층", "13529",
+			LATITUDE, LONGITUDE, CategoryType.SPORTS, RegionType.GANGNAM
 		);
 		UUID fileId = UUID.randomUUID();
 		given(validateFileUseCase.validateAndConfirm(any())).willReturn(new FileConfirmResponse(fileId, "user/file/image.jpg"));
@@ -145,10 +149,6 @@ class ProductCUDTest {
 		assertThat(saved.title()).isEqualTo("테스트상품");
 		assertThat(saved.thumbnailPath()).isEqualTo("user/file/image.jpg");
 		assertThat(saved.roadAddress()).isEqualTo("경기 성남시 분당구 판교역로 166");
-		assertThat(saved.detailAddress()).isEqualTo("카카오 판교 아지트 1층");
-		assertThat(saved.zonecode()).isEqualTo("13529");
-		assertThat(saved.latitude()).isEqualByComparingTo(LATITUDE);
-		assertThat(saved.longitude()).isEqualByComparingTo(LONGITUDE);
 		then(publisher).should().publishEvent(any(ProductEventResponseDto.class));
 		then(outboxRepository).should().save(any(OutboxEvent.class));
 	}
@@ -156,18 +156,10 @@ class ProductCUDTest {
 	@Test
 	void 최대인원이_0이면_상품_생성_검증에_실패한다() {
 		CreateProductRequestDto request = new CreateProductRequestDto(
-			SELLER_ID,
-			"테스트상품",
-			0,
-			"테스트 상품입니다.",
-			List.of(UUID.randomUUID()),
-			PRICE,
-			ProductStatus.ENABLE,
-			"경기 성남시 분당구 판교역로 166",
-			"카카오 판교 아지트 1층",
-			"13529",
-			LATITUDE,
-			LONGITUDE
+			SELLER_ID, "테스트상품", 0, "테스트 상품입니다.",
+			List.of(UUID.randomUUID()), PRICE, ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166", "카카오 판교 아지트 1층", "13529",
+			LATITUDE, LONGITUDE, CategoryType.SPORTS, RegionType.GANGNAM
 		);
 
 		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
@@ -179,18 +171,10 @@ class ProductCUDTest {
 	@Test
 	void 상품명이_비어있으면_상품_생성_검증에_실패한다() {
 		CreateProductRequestDto request = new CreateProductRequestDto(
-			SELLER_ID,
-			"",
-			10,
-			"테스트 상품입니다.",
-			List.of(UUID.randomUUID()),
-			PRICE,
-			ProductStatus.ENABLE,
-			"경기 성남시 분당구 판교역로 166",
-			"카카오 판교 아지트 1층",
-			"13529",
-			LATITUDE,
-			LONGITUDE
+			SELLER_ID, "", 10, "테스트 상품입니다.",
+			List.of(UUID.randomUUID()), PRICE, ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166", "카카오 판교 아지트 1층", "13529",
+			LATITUDE, LONGITUDE, CategoryType.SPORTS, RegionType.GANGNAM
 		);
 
 		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
@@ -202,18 +186,10 @@ class ProductCUDTest {
 	@Test
 	void 판매자ID가_없으면_상품_생성_검증에_실패한다() {
 		CreateProductRequestDto request = new CreateProductRequestDto(
-			null,
-			"테스트상품",
-			10,
-			"테스트 상품입니다.",
-			List.of(UUID.randomUUID()),
-			PRICE,
-			ProductStatus.ENABLE,
-			"경기 성남시 분당구 판교역로 166",
-			"카카오 판교 아지트 1층",
-			"13529",
-			LATITUDE,
-			LONGITUDE
+			null, "테스트상품", 10, "테스트 상품입니다.",
+			List.of(UUID.randomUUID()), PRICE, ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166", "카카오 판교 아지트 1층", "13529",
+			LATITUDE, LONGITUDE, CategoryType.SPORTS, RegionType.GANGNAM
 		);
 
 		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
@@ -225,18 +201,10 @@ class ProductCUDTest {
 	@Test
 	void 가격이_0이면_상품_생성_검증에_실패한다() {
 		CreateProductRequestDto request = new CreateProductRequestDto(
-			SELLER_ID,
-			"테스트상품",
-			10,
-			"테스트 상품입니다.",
-			List.of(UUID.randomUUID()),
-			BigDecimal.ZERO,
-			ProductStatus.ENABLE,
-			"경기 성남시 분당구 판교역로 166",
-			"카카오 판교 아지트 1층",
-			"13529",
-			LATITUDE,
-			LONGITUDE
+			SELLER_ID, "테스트상품", 10, "테스트 상품입니다.",
+			List.of(UUID.randomUUID()), BigDecimal.ZERO, ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166", "카카오 판교 아지트 1층", "13529",
+			LATITUDE, LONGITUDE, CategoryType.SPORTS, RegionType.GANGNAM
 		);
 
 		Set<ConstraintViolation<CreateProductRequestDto>> violations = validator.validate(request);
@@ -248,18 +216,10 @@ class ProductCUDTest {
 	@Test
 	void 판매자가_존재하지_않으면_상품_생성에_실패한다() {
 		CreateProductRequestDto request = new CreateProductRequestDto(
-			SELLER_ID,
-			"테스트상품",
-			5,
-			"테스트 상품입니다.",
-			null,
-			PRICE,
-			ProductStatus.ENABLE,
-			"경기 성남시 분당구 판교역로 166",
-			"카카오 판교 아지트 1층",
-			"13529",
-			LATITUDE,
-			LONGITUDE
+			SELLER_ID, "테스트상품", 5, "테스트 상품입니다.",
+			null, PRICE, ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166", "카카오 판교 아지트 1층", "13529",
+			LATITUDE, LONGITUDE, CategoryType.SPORTS, RegionType.GANGNAM
 		);
 		given(sellerRepository.findSeller(SELLER_ID)).willReturn(Optional.empty());
 
@@ -271,17 +231,11 @@ class ProductCUDTest {
 	@Test
 	void 상품_수정시_추가된_주소와_좌표_컬럼도_변경한다() {
 		UpdateProductRequestDto request = new UpdateProductRequestDto(
-			"수정상품",
-			10,
-			"수정 설명",
-			List.of(UUID.randomUUID()),
-			new BigDecimal("1200.00"),
-			ProductStatus.ENABLE,
-			"서울 강남구 테헤란로 123",
-			"3층",
-			"06234",
-			new BigDecimal("37.1234567"),
-			new BigDecimal("127.7654321")
+			"수정상품", 10, "수정 설명", List.of(UUID.randomUUID()),
+			new BigDecimal("1200.00"), ProductStatus.ENABLE,
+			"서울 강남구 테헤란로 123", "3층", "06234",
+			new BigDecimal("37.1234567"), new BigDecimal("127.7654321"),
+			CategoryType.SPORTS, RegionType.GANGNAM
 		);
 		UUID fileId = UUID.randomUUID();
 		given(validateFileUseCase.validateAndConfirm(any())).willReturn(new FileConfirmResponse(fileId, "user/file/image.jpg"));
@@ -300,27 +254,17 @@ class ProductCUDTest {
 
 		assertThat(updated.title()).isEqualTo("수정상품");
 		assertThat(updated.roadAddress()).isEqualTo("서울 강남구 테헤란로 123");
-		assertThat(updated.detailAddress()).isEqualTo("3층");
-		assertThat(updated.zonecode()).isEqualTo("06234");
-		assertThat(updated.latitude()).isEqualByComparingTo("37.1234567");
-		assertThat(updated.longitude()).isEqualByComparingTo("127.7654321");
 		then(outboxRepository).should().save(any(OutboxEvent.class));
 	}
 
 	@Test
 	void 존재하지_않는_상품은_수정에_실패한다() {
 		UpdateProductRequestDto request = new UpdateProductRequestDto(
-			"수정상품",
-			10,
-			"수정 설명",
-			List.of(UUID.randomUUID()),
-			new BigDecimal("1200.00"),
-			ProductStatus.ENABLE,
-			"서울 강남구 테헤란로 123",
-			"3층",
-			"06234",
-			new BigDecimal("37.1234567"),
-			new BigDecimal("127.7654321")
+			"수정상품", 10, "수정 설명", List.of(UUID.randomUUID()),
+			new BigDecimal("1200.00"), ProductStatus.ENABLE,
+			"서울 강남구 테헤란로 123", "3층", "06234",
+			new BigDecimal("37.1234567"), new BigDecimal("127.7654321"),
+			CategoryType.SPORTS, RegionType.GANGNAM
 		);
 		given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.empty());
 
@@ -353,17 +297,11 @@ class ProductCUDTest {
 	@Test
 	void 다른_판매자의_상품은_수정할_수_없다() {
 		UpdateProductRequestDto request = new UpdateProductRequestDto(
-			"수정상품",
-			10,
-			"수정 설명",
-			List.of(UUID.randomUUID()),
-			new BigDecimal("1200.00"),
-			ProductStatus.ENABLE,
-			"서울 강남구 테헤란로 123",
-			"3층",
-			"06234",
-			new BigDecimal("37.1234567"),
-			new BigDecimal("127.7654321")
+			"수정상품", 10, "수정 설명", List.of(UUID.randomUUID()),
+			new BigDecimal("1200.00"), ProductStatus.ENABLE,
+			"서울 강남구 테헤란로 123", "3층", "06234",
+			new BigDecimal("37.1234567"), new BigDecimal("127.7654321"),
+			CategoryType.SPORTS, RegionType.GANGNAM
 		);
 		given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.of(product));
 		given(productRepository.findByIdAndSellerId(PRODUCT_ID, SELLER_ID)).willReturn(Optional.empty());

--- a/service/product/src/test/java/jabaclass/product/ProductRestControllerTest.java
+++ b/service/product/src/test/java/jabaclass/product/ProductRestControllerTest.java
@@ -21,7 +21,9 @@ import org.springframework.http.ResponseEntity;
 import jabaclass.product.application.usecase.ProductUseCase;
 import jabaclass.product.application.usecase.ProductUserUseCase;
 import jabaclass.product.common.exception.ApiResponseDto;
+import jabaclass.product.domain.model.status.CategoryType;
 import jabaclass.product.domain.model.status.ProductStatus;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.model.status.ReservationStatus;
 import jabaclass.product.presentation.controller.ProductRestController;
 import jabaclass.product.presentation.dto.request.CreateProductRequestDto;
@@ -56,32 +58,19 @@ class ProductRestControllerTest {
 	@BeforeEach
 	void setUp() {
 		createRequest = new CreateProductRequestDto(
-			SELLER_ID,
-			"상품",
-			10,
-			"설명",
-			List.of(UUID.randomUUID()),
-			new BigDecimal("10000"),
-			ProductStatus.ENABLE,
-			"경기 성남시 분당구 판교역로 166",
-			"카카오 판교 아지트 1층",
-			"13529",
-			new BigDecimal("37.3952000"),
-			new BigDecimal("127.1110000")
+			SELLER_ID, "상품", 10, "설명",
+			List.of(UUID.randomUUID()), new BigDecimal("10000"), ProductStatus.ENABLE,
+			"경기 성남시 분당구 판교역로 166", "카카오 판교 아지트 1층", "13529",
+			new BigDecimal("37.3952000"), new BigDecimal("127.1110000"),
+			CategoryType.SPORTS, RegionType.GANGNAM
 		);
 
 		updateRequest = new UpdateProductRequestDto(
-			"수정상품",
-			20,
-			"수정설명",
-			List.of(UUID.randomUUID()),
-			new BigDecimal("20000"),
-			ProductStatus.DISABLE,
-			"서울 강남구 테헤란로 123",
-			"3층",
-			"06234",
-			new BigDecimal("37.1234567"),
-			new BigDecimal("127.7654321")
+			"수정상품", 20, "수정설명",
+			List.of(UUID.randomUUID()), new BigDecimal("20000"), ProductStatus.DISABLE,
+			"서울 강남구 테헤란로 123", "3층", "06234",
+			new BigDecimal("37.1234567"), new BigDecimal("127.7654321"),
+			CategoryType.SPORTS, RegionType.GANGNAM
 		);
 
 		productResponse = new ProductResponseDto(
@@ -100,7 +89,9 @@ class ProductRestControllerTest {
 			"카카오 판교 아지트 1층",
 			"13529",
 			new BigDecimal("37.3952000"),
-			new BigDecimal("127.1110000")
+			new BigDecimal("127.1110000"),
+			0L,
+			0L
 		);
 	}
 

--- a/service/product/src/test/java/jabaclass/product/ProductSearchTest.java
+++ b/service/product/src/test/java/jabaclass/product/ProductSearchTest.java
@@ -5,10 +5,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.lenient;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -20,15 +21,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import jabaclass.product.application.acl.SellerRepository;
 import jabaclass.product.application.service.ProductService;
+import jabaclass.product.application.usecase.FavoriteUseCase;
 import jabaclass.product.application.usecase.ValidateFileUseCase;
+import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.status.CategoryType;
 import jabaclass.product.domain.model.status.ProductStatus;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.repository.ProductRepository;
 import jabaclass.product.domain.repository.ProductSearchRepository;
-import jabaclass.product.infrastructure.elasticsearch.ProductDocument;
+import jabaclass.product.infrastructure.acl.dto.response.UserResponseDto;
 import jabaclass.product.presentation.dto.request.SearchProductRequestDto;
 import jabaclass.product.presentation.dto.response.ProductResponseDto;
 import jabaclass.product.presentation.dto.response.SearchProductResponseDto;
@@ -54,86 +63,101 @@ class ProductSearchTest {
 	@Mock
 	private ValidateFileUseCase validateFileUseCase;
 
+	@Mock
+	private StringRedisTemplate redisTemplate;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	@Mock
+	private FavoriteUseCase favoriteUseCase;
+
 	private static final UUID SELLER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 	private static final BigDecimal PRICE = new BigDecimal("1000.50");
 
-	private ProductDocument doc1;
-	private ProductDocument doc2;
+	private Product product1;
+	private Product product2;
 
 	@BeforeEach
 	void setUp() {
-		doc1 = ProductDocument.builder()
-			.id(UUID.randomUUID().toString())
-			.sellerId(SELLER_ID.toString())
-			.sellerName("판매자A")
-			.title("향수 공방 클래스")
-			.description("직접 향수를 만들어보는 클래스입니다.")
-			.status("ENABLE")
-			.price(PRICE)
-			.maxCapacity(10)
-			.deleted(false)
-			.build();
+		lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+		lenient().when(valueOperations.multiGet(any())).thenReturn(List.of());
 
-		doc2 = ProductDocument.builder()
-			.id(UUID.randomUUID().toString())
-			.sellerId(SELLER_ID.toString())
-			.sellerName("판매자A")
-			.title("캔들 공방 클래스")
-			.description("직접 캔들을 만들어보는 클래스입니다.")
-			.status("ENABLE")
-			.price(PRICE)
-			.maxCapacity(5)
-			.deleted(false)
+		product1 = Product.builder()
+			.sellerId(SELLER_ID).title("향수 공방 클래스").maxCapacity(10)
+			.description("직접 향수를 만들어보는 클래스입니다.").price(PRICE)
+			.status(ProductStatus.ENABLE).roadAddress("서울시 강남구")
+			.latitude(BigDecimal.valueOf(37.5)).longitude(BigDecimal.valueOf(127.0))
+			.category(CategoryType.ART).region(RegionType.GANGNAM)
 			.build();
+		ReflectionTestUtils.setField(product1, "id", UUID.randomUUID());
+
+		product2 = Product.builder()
+			.sellerId(SELLER_ID).title("캔들 공방 클래스").maxCapacity(5)
+			.description("직접 캔들을 만들어보는 클래스입니다.").price(PRICE)
+			.status(ProductStatus.ENABLE).roadAddress("서울시 강남구")
+			.latitude(BigDecimal.valueOf(37.5)).longitude(BigDecimal.valueOf(127.0))
+			.category(CategoryType.ART).region(RegionType.GANGNAM)
+			.build();
+		ReflectionTestUtils.setField(product2, "id", UUID.randomUUID());
 	}
 
 	@Test
-	void 키워드가_없으면_전체_ENABLE_상품을_ES에서_조회한다() {
+	void 키워드가_없으면_전체_ENABLE_상품을_MySQL에서_조회한다() {
 		SearchProductRequestDto request = new SearchProductRequestDto("", 0, 10, ProductStatus.ENABLE);
-		Page<ProductDocument> esPage = new PageImpl<>(List.of(doc1, doc2));
-		given(productSearchRepository.findAllEnabled(any(Pageable.class))).willReturn(esPage);
+		Page<Product> dbPage = new PageImpl<>(List.of(product1, product2));
+		given(productRepository.findByStatusAndDeleteDtIsNull(eq(ProductStatus.ENABLE), any(Pageable.class)))
+			.willReturn(dbPage);
+		given(sellerRepository.findSellerList(any()))
+			.willReturn(Optional.of(List.of(new UserResponseDto(SELLER_ID, "판매자A", "SELLER"))));
 
 		SearchProductResponseDto result = productService.searchAll(request);
 
 		assertThat(result.totalCount()).isEqualTo(2);
 		assertThat(result.content()).extracting(ProductResponseDto::title)
 			.containsExactlyInAnyOrder("향수 공방 클래스", "캔들 공방 클래스");
-		then(productSearchRepository).should().findAllEnabled(any(Pageable.class));
-		then(productSearchRepository).should(never()).searchByKeyword(any(), any());
+		then(productRepository).should().findByStatusAndDeleteDtIsNull(any(), any());
 	}
 
 	@Test
-	void 키워드가_있으면_ES_검색을_호출한다() {
+	void 키워드가_있으면_MySQL_키워드_검색을_호출한다() {
 		SearchProductRequestDto request = new SearchProductRequestDto("향수", 0, 10, ProductStatus.ENABLE);
-		Page<ProductDocument> esPage = new PageImpl<>(List.of(doc1));
-		given(productSearchRepository.searchByKeyword(eq("향수"), any(Pageable.class))).willReturn(esPage);
+		Page<Product> dbPage = new PageImpl<>(List.of(product1));
+		given(productRepository.findByStatusAndTitleContainingAndDeleteDtIsNull(
+			eq(ProductStatus.ENABLE), eq("향수"), any(Pageable.class)))
+			.willReturn(dbPage);
+		given(sellerRepository.findSellerList(any()))
+			.willReturn(Optional.of(List.of(new UserResponseDto(SELLER_ID, "판매자A", "SELLER"))));
 
 		SearchProductResponseDto result = productService.searchAll(request);
 
 		assertThat(result.totalCount()).isEqualTo(1);
 		assertThat(result.content()).extracting(ProductResponseDto::title)
 			.containsExactly("향수 공방 클래스");
-		then(productSearchRepository).should().searchByKeyword(eq("향수"), any(Pageable.class));
-		then(productSearchRepository).should(never()).findAllEnabled(any());
+		then(productRepository).should().findByStatusAndTitleContainingAndDeleteDtIsNull(any(), any(), any());
 	}
 
 	@Test
-	void ES_검색결과에는_sellerName이_포함된다() {
+	void 검색결과에는_sellerName이_포함된다() {
 		SearchProductRequestDto request = new SearchProductRequestDto("공방", 0, 10, ProductStatus.ENABLE);
-		Page<ProductDocument> esPage = new PageImpl<>(List.of(doc1, doc2));
-		given(productSearchRepository.searchByKeyword(eq("공방"), any(Pageable.class))).willReturn(esPage);
+		Page<Product> dbPage = new PageImpl<>(List.of(product1, product2));
+		given(productRepository.findByStatusAndTitleContainingAndDeleteDtIsNull(any(), any(), any()))
+			.willReturn(dbPage);
+		given(sellerRepository.findSellerList(any()))
+			.willReturn(Optional.of(List.of(new UserResponseDto(SELLER_ID, "판매자A", "SELLER"))));
 
 		SearchProductResponseDto result = productService.searchAll(request);
 
 		assertThat(result.content()).extracting(ProductResponseDto::sellerName)
 			.containsOnly("판매자A");
-		then(sellerRepository).shouldHaveNoInteractions();
 	}
 
 	@Test
 	void 검색_결과가_없으면_빈_리스트를_반환한다() {
 		SearchProductRequestDto request = new SearchProductRequestDto("없는키워드", 0, 10, ProductStatus.ENABLE);
-		given(productSearchRepository.searchByKeyword(any(), any(Pageable.class))).willReturn(new PageImpl<>(List.of()));
+		given(productRepository.findByStatusAndTitleContainingAndDeleteDtIsNull(any(), any(), any()))
+			.willReturn(new PageImpl<>(List.of()));
+		given(sellerRepository.findSellerList(any())).willReturn(Optional.of(List.of()));
 
 		SearchProductResponseDto result = productService.searchAll(request);
 
@@ -144,12 +168,14 @@ class ProductSearchTest {
 	@Test
 	void 페이지_정보가_올바르게_반환된다() {
 		SearchProductRequestDto request = new SearchProductRequestDto("", 2, 5, ProductStatus.ENABLE);
-		Page<ProductDocument> esPage = new PageImpl<>(
-			List.of(doc1),
-			org.springframework.data.domain.PageRequest.of(2, 5),
+		Page<Product> dbPage = new PageImpl<>(
+			List.of(product1),
+			PageRequest.of(2, 5),
 			11
 		);
-		given(productSearchRepository.findAllEnabled(any(Pageable.class))).willReturn(esPage);
+		given(productRepository.findByStatusAndDeleteDtIsNull(any(), any())).willReturn(dbPage);
+		given(sellerRepository.findSellerList(any()))
+			.willReturn(Optional.of(List.of(new UserResponseDto(SELLER_ID, "판매자A", "SELLER"))));
 
 		SearchProductResponseDto result = productService.searchAll(request);
 

--- a/service/product/src/test/java/jabaclass/product/ProductSelectTest.java
+++ b/service/product/src/test/java/jabaclass/product/ProductSelectTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.lenient;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -21,19 +22,23 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import jabaclass.product.application.acl.SellerRepository;
 import jabaclass.product.application.exception.BusinessException;
 import jabaclass.product.application.service.ProductService;
+import jabaclass.product.application.usecase.FavoriteUseCase;
 import jabaclass.product.application.usecase.ValidateFileUseCase;
 import jabaclass.product.common.exception.CommonErrorCode;
 import jabaclass.product.domain.model.Product;
+import jabaclass.product.domain.model.status.CategoryType;
 import jabaclass.product.domain.model.status.ProductStatus;
+import jabaclass.product.domain.model.status.RegionType;
 import jabaclass.product.domain.repository.ProductRepository;
 import jabaclass.product.domain.repository.ProductSearchRepository;
 import jabaclass.product.infrastructure.acl.dto.response.UserResponseDto;
-import jabaclass.product.infrastructure.elasticsearch.ProductDocument;
 import jabaclass.product.presentation.dto.request.SearchProductRequestDto;
 import jabaclass.product.presentation.dto.response.ProductResponseDto;
 import jabaclass.product.presentation.dto.response.SearchProductResponseDto;
@@ -59,6 +64,15 @@ class ProductSelectTest {
 	@Mock
 	private ValidateFileUseCase validateFileUseCase;
 
+	@Mock
+	private StringRedisTemplate redisTemplate;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	@Mock
+	private FavoriteUseCase favoriteUseCase;
+
 	private static final BigDecimal PRICE = new BigDecimal("1000.50");
 	private static final UUID SELLER_ID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
 	private static final UUID PRODUCT_ID = UUID.fromString("223e4567-e89b-12d3-a456-426614174000");
@@ -74,47 +88,34 @@ class ProductSelectTest {
 			.description("테스트")
 			.price(PRICE)
 			.status(ProductStatus.ENABLE)
+			.roadAddress("서울시 강남구")
+			.latitude(BigDecimal.valueOf(37.5))
+			.longitude(BigDecimal.valueOf(127.0))
+			.category(CategoryType.SPORTS)
+			.region(RegionType.GANGNAM)
 			.build();
 		ReflectionTestUtils.setField(product1, "id", PRODUCT_ID);
+
+		lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 	}
 
 	@Test
 	void 전체_상품을_조회한다() {
 		SearchProductRequestDto request = new SearchProductRequestDto("", 0, 10, ProductStatus.ENABLE);
+		Page<Product> dbPage = new PageImpl<>(List.of(product1));
 
-		ProductDocument doc1 = ProductDocument.builder()
-			.id(PRODUCT_ID.toString())
-			.sellerId(SELLER_ID.toString())
-			.sellerName("판매자")
-			.title("상품A")
-			.description("테스트")
-			.status("ENABLE")
-			.price(PRICE)
-			.maxCapacity(10)
-			.deleted(false)
-			.build();
-		ProductDocument doc2 = ProductDocument.builder()
-			.id(UUID.randomUUID().toString())
-			.sellerId(SELLER_ID.toString())
-			.sellerName("판매자")
-			.title("상품B")
-			.description("테스트")
-			.status("ENABLE")
-			.price(PRICE)
-			.maxCapacity(3)
-			.deleted(false)
-			.build();
-
-		Page<ProductDocument> esPage = new PageImpl<>(List.of(doc1, doc2));
-		given(productSearchRepository.findAllEnabled(any(Pageable.class))).willReturn(esPage);
+		given(productRepository.findByStatusAndDeleteDtIsNull(any(ProductStatus.class), any(Pageable.class)))
+			.willReturn(dbPage);
+		given(sellerRepository.findSellerList(any()))
+			.willReturn(Optional.of(List.of(new UserResponseDto(SELLER_ID, "판매자", "SELLER"))));
+		given(valueOperations.multiGet(any())).willReturn(List.of());
 
 		SearchProductResponseDto result = productService.searchAll(request);
 
 		assertThat(result.content()).extracting(ProductResponseDto::title)
-			.containsExactly("상품A", "상품B");
-		assertThat(result.totalCount()).isEqualTo(2);
-		then(productSearchRepository).should().findAllEnabled(any(Pageable.class));
-		then(productRepository).shouldHaveNoInteractions();
+			.containsExactly("상품A");
+		assertThat(result.totalCount()).isEqualTo(1);
+		then(productRepository).should().findByStatusAndDeleteDtIsNull(any(), any());
 	}
 
 	@Test
@@ -122,6 +123,10 @@ class ProductSelectTest {
 		given(productRepository.findById(PRODUCT_ID)).willReturn(Optional.of(product1));
 		given(sellerRepository.findSeller(SELLER_ID))
 			.willReturn(Optional.of(new UserResponseDto(SELLER_ID, "테스트판매자", "SELLER")));
+		given(favoriteUseCase.getLikeCount(PRODUCT_ID)).willReturn(0L);
+		given(redisTemplate.hasKey(any())).willReturn(false);
+		given(valueOperations.setIfAbsent(any(), any())).willReturn(true);
+		given(valueOperations.increment(any())).willReturn(1L);
 
 		ProductResponseDto result = productService.searchById(PRODUCT_ID, null);
 


### PR DESCRIPTION
## 관련 이슈
  - Close #10

  ## 변경 요약
  - 좋아요 수 Write-Through 전략 구현 (DB 즉시 반영
   → Redis INCR/DECR 동기 갱신)
  - 조회수 Write-Behind 전략 구현 (Redis INCR →
  매시 정각 DB 반영)
  - 상품 목록/상세 응답에 likeCount, viewCount 통합

  ## 주요 변경점
  - **좋아요**: 생성/취소 시 DB 반영 후 Redis
  `like_count` 갱신, 갱신 실패 시 매일 03:00 DB
  기준 재동기화
  - **조회수**: 상세 조회 시 DB update 없이 Redis
  INCR만 수행, 매시 정각 DB 반영
  - **읽기**: 두 카운터 모두 Cache-Aside (Redis
  우선 → miss 시 `setIfAbsent`로 초기화)
  - **배치 최적화**: 목록 조회 시 `multiGet()`으로
  카운터 N개를 한 번에 조회

  ## 테스트
  - [x] 로컬 실행 확인
  - [x] 테스트 통과
